### PR TITLE
Add child momentary switch EPs with number and position tags

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -44,7 +44,7 @@ import {
 } from 'matterbridge';
 import { isValidBoolean, isValidNumber } from 'matterbridge/utils';
 import { AnsiLogger } from 'matterbridge/logger';
-import { LocationTag } from 'matterbridge/matter';
+import { LocationTag, NumberTag, PositionTag } from 'matterbridge/matter';
 import {
   PowerSource,
   BooleanState,
@@ -1436,7 +1436,15 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
     }
 
     /** ********************* Create a momentary switch ***********************/
-    this.momentarySwitch = new MatterbridgeEndpoint([genericSwitch, bridgedNode, powerSource], { uniqueStorageKey: 'Momentary switch' }, this.config.debug as boolean)
+    this.momentarySwitch = new MatterbridgeEndpoint([genericSwitch, bridgedNode, powerSource],
+      {
+        tagList: [
+          { mfgCode: null, namespaceId: NumberTag.One.namespaceId, tag: NumberTag.One.tag, label: NumberTag.One.label },
+          { mfgCode: null, namespaceId: PositionTag.Top.namespaceId, tag: PositionTag.Top.tag, label: PositionTag.Top.label }
+        ],
+        uniqueStorageKey: 'Momentary switch' 
+
+      }, this.config.debug as boolean)
       .createDefaultBridgedDeviceBasicInformationClusterServer(
         'Momentary switch',
         'serial_947942331225',
@@ -1451,6 +1459,27 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
       .createDefaultIdentifyClusterServer()
       .createDefaultSwitchClusterServer()
       .createDefaultPowerSourceReplaceableBatteryClusterServer(50, PowerSource.BatChargeLevel.Ok, 2900, 'CR2450', 1);
+
+    this.momentarySwitch
+      .addChildDeviceType('momentarySwitch2', [genericSwitch], {
+        tagList: [
+          { mfgCode: null, namespaceId: NumberTag.Two.namespaceId, tag: NumberTag.Two.tag, label: NumberTag.Two.label },
+          { mfgCode: null, namespaceId: PositionTag.Middle.namespaceId, tag: PositionTag.Middle.tag, label: PositionTag.Middle.label }
+        ],
+      })
+      .createDefaultIdentifyClusterServer()
+      .createDefaultSwitchClusterServer();
+
+    this.momentarySwitch
+      .addChildDeviceType('momentarySwitch3', [genericSwitch], {
+        tagList: [
+          { mfgCode: null, namespaceId: NumberTag.Three.namespaceId, tag: NumberTag.Three.tag, label: NumberTag.Three.label },
+          { mfgCode: null, namespaceId: PositionTag.Bottom.namespaceId, tag: PositionTag.Bottom.tag, label: PositionTag.Bottom.label }
+        ],
+      })
+      .createDefaultIdentifyClusterServer()
+      .createDefaultSwitchClusterServer();
+
     this.setSelectDevice(this.momentarySwitch.serialNumber ?? '', this.momentarySwitch.deviceName ?? '', undefined, 'hub');
     if (this.validateDevice(this.momentarySwitch.deviceName ?? '')) {
       await this.registerDevice(this.momentarySwitch);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1436,15 +1436,17 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
     }
 
     /** ********************* Create a momentary switch ***********************/
-    this.momentarySwitch = new MatterbridgeEndpoint([genericSwitch, bridgedNode, powerSource],
+    this.momentarySwitch = new MatterbridgeEndpoint(
+      [genericSwitch, bridgedNode, powerSource],
       {
         tagList: [
           { mfgCode: null, namespaceId: NumberTag.One.namespaceId, tag: NumberTag.One.tag, label: NumberTag.One.label },
-          { mfgCode: null, namespaceId: PositionTag.Top.namespaceId, tag: PositionTag.Top.tag, label: PositionTag.Top.label }
+          { mfgCode: null, namespaceId: PositionTag.Top.namespaceId, tag: PositionTag.Top.tag, label: PositionTag.Top.label },
         ],
-        uniqueStorageKey: 'Momentary switch' 
-
-      }, this.config.debug as boolean)
+        uniqueStorageKey: 'Momentary switch',
+      },
+      this.config.debug as boolean,
+    )
       .createDefaultBridgedDeviceBasicInformationClusterServer(
         'Momentary switch',
         'serial_947942331225',
@@ -1464,7 +1466,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
       .addChildDeviceType('momentarySwitch2', [genericSwitch], {
         tagList: [
           { mfgCode: null, namespaceId: NumberTag.Two.namespaceId, tag: NumberTag.Two.tag, label: NumberTag.Two.label },
-          { mfgCode: null, namespaceId: PositionTag.Middle.namespaceId, tag: PositionTag.Middle.tag, label: PositionTag.Middle.label }
+          { mfgCode: null, namespaceId: PositionTag.Middle.namespaceId, tag: PositionTag.Middle.tag, label: PositionTag.Middle.label },
         ],
       })
       .createDefaultIdentifyClusterServer()
@@ -1474,7 +1476,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
       .addChildDeviceType('momentarySwitch3', [genericSwitch], {
         tagList: [
           { mfgCode: null, namespaceId: NumberTag.Three.namespaceId, tag: NumberTag.Three.tag, label: NumberTag.Three.label },
-          { mfgCode: null, namespaceId: PositionTag.Bottom.namespaceId, tag: PositionTag.Bottom.tag, label: PositionTag.Bottom.label }
+          { mfgCode: null, namespaceId: PositionTag.Bottom.namespaceId, tag: PositionTag.Bottom.tag, label: PositionTag.Bottom.label },
         ],
       })
       .createDefaultIdentifyClusterServer()


### PR DESCRIPTION
Add child momentary switch EPs with number and position tags to demonstrates the use of :
- `Taglist` Feature of `Descriptor` Cluster : used to disambiguate sibling endpoints where two or more sibling endpoints have an overlap in the supported device types with each such endpoint having a unique TagList.

## Testing

![image](https://github.com/user-attachments/assets/4ba733ee-e450-4ead-be52-694961e41b82)


```
[17:47:35.808] [Endpoint] Matterbridge.Matterbridge.Momentaryswitch ready endpoint#: 37 type: MA_genericswitch (0xf) behaviors: ✓descriptor 💤matterbridge ✓bridgedDeviceBasicInformation ✓identify ✓switch ✓powerSource
[17:47:35.833] [Endpoint] Matterbridge.Matterbridge.Momentaryswitch.momentarySwitch2 ready endpoint#: 61 type: MA_genericswitch (0xf) behaviors: ✓descriptor 💤matterbridge ✓identify ✓switch
[17:47:35.835] [Endpoint] Matterbridge.Matterbridge.Momentaryswitch.momentarySwitch3 ready endpoint#: 62 type: MA_genericswitch (0xf) behaviors: ✓descriptor 💤matterbridge ✓identify ✓switch
[17:47:35.838] [Matterbridge] Subscribing attributes for endpoint Momentary switch (Momentaryswitch) plugin matterbridge-example-dynamic-platform
[17:47:35.839] [Matterbridge] Added and registered bridged endpoint (29/29) Momentary switch (Momentaryswitch) for plugin matterbridge-example-dynamic-platform
```
