### PR TITLE
Remove the supportedMaps workaround for the RVC maps

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1364,17 +1364,17 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
         },
         {
           areaId: 2,
-          mapId: 2,
+          mapId: 1,
           areaInfo: { locationInfo: { locationName: 'Kitchen', floorNumber: 0, areaType: AreaNamespaceTag.Kitchen.tag }, landmarkInfo: null },
         },
         {
           areaId: 3,
-          mapId: 3,
+          mapId: 2,
           areaInfo: { locationInfo: { locationName: 'Bedroom', floorNumber: 1, areaType: AreaNamespaceTag.Bedroom.tag }, landmarkInfo: null },
         },
         {
           areaId: 4,
-          mapId: 4,
+          mapId: 2,
           areaInfo: { locationInfo: { locationName: 'Bathroom', floorNumber: 1, areaType: AreaNamespaceTag.Bathroom.tag }, landmarkInfo: null },
         },
       ], // supportedAreas
@@ -1388,16 +1388,6 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
         {
           mapId: 2,
           name: 'First floor',
-        },
-        /* Workaround because waiting for a matter.js fix https://github.com/project-chip/matter.js/issues/2238 */
-        {
-          mapId: 3,
-          name: 'Bedroom',
-        },
-        /* Workaround because waiting for a matter.js fix */
-        {
-          mapId: 4,
-          name: 'Bathroom',
         },
       ], // supportedMaps
     );


### PR DESCRIPTION
## Summary
- [platform]: Remove the supportedMaps workaround for the RVC maps since the fix is included in matter.js 0.15.2.

## Testing

Tested with Apple Home. It works fine so we can have many rooms in a map now.

![IMG_3599](https://github.com/user-attachments/assets/6c8e532f-33bf-41d2-afa6-2f3d91ad410e)

![IMG_3600](https://github.com/user-attachments/assets/0623e47f-845b-4ee6-9d16-24892b431651)