### PR TITLE
Add Refrigerator Semantic Tag Namespace

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1542,8 +1542,15 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
 
     // *********************** Create an Refrigerator **************************
     const refrigerator = new Refrigerator('Refrigerator', 'RE1234567890');
-    refrigerator.addCabinet('Refrigerator Top', [{ mfgCode: null, namespaceId: PositionTag.Top.namespaceId, tag: PositionTag.Top.tag, label: 'Refrigerator Top' }]);
-    refrigerator.addCabinet('Freezer Bottom', [{ mfgCode: null, namespaceId: PositionTag.Bottom.namespaceId, tag: PositionTag.Bottom.tag, label: 'Freezer Bottom' }]);
+    refrigerator.addCabinet('Refrigerator Top', [
+      { mfgCode: null, namespaceId: PositionTag.Top.namespaceId, tag: PositionTag.Top.tag, label: 'Refrigerator Top' },
+      { mfgCode: null, namespaceId: RefrigeratorTag.namespaceId, tag: RefrigeratorTag.Refrigerator.tag, label: RefrigeratorTag.Refrigerator.label },
+    ]);
+    refrigerator.addCabinet('Freezer Bottom', [
+      { mfgCode: null, namespaceId: PositionTag.Bottom.namespaceId, tag: PositionTag.Bottom.tag, label: 'Freezer Bottom' },
+      { mfgCode: null, namespaceId: RefrigeratorTag.namespaceId, tag: RefrigeratorTag.Freezer.tag, label: RefrigeratorTag.Freezer.label },
+
+    ]);
     this.refrigerator = (await this.addDevice(refrigerator)) as Refrigerator | undefined;
   }
 


### PR DESCRIPTION
We should add the Refrigerator Semantic Tag Namespace too. It allows to find which EP is the `Refrigerator` and which is the `Freezer`
<img width="872" height="568" alt="image" src="https://github.com/user-attachments/assets/e18f5735-4933-432c-a26b-a04aa50ab090" />


Example in the SDK:  https://github.com/project-chip/connectedhomeip/blob/master/examples/refrigerator-app/silabs/src/RefrigeratorManager.cpp#L53-L63