### PR TITLE
Log DoorLock OperatingMode attribute

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -90,7 +90,6 @@ import {
   FlowMeasurement,
   ColorControl,
   DoorLock,
-  DoorLockCluster,
   FanControl,
   FormaldehydeConcentrationMeasurement,
   NitrogenDioxideConcentrationMeasurement,
@@ -790,7 +789,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
       this.lock?.log.info('Command unlockDoor called');
     });
     await this.lock?.subscribeAttribute(
-      DoorLockCluster.id,
+      DoorLock.Cluster.id,
       'operatingMode',
       (value) => {
         const lookupOperatingMode = ['Normal', 'Vacation', 'Privacy', 'NoRemoteLockUnlock', 'Passage'];


### PR DESCRIPTION
## Change

Log `DoorLock` cluster `OperatingMode` attribute.
This allows you to test and track mode changes.

## Ref

https://github.com/matter-js/matter.js/blob/6d3f461c5514f5ff8969f6d249dc2d21ae41b781/packages/types/src/clusters/door-lock.ts#L1753-L1792

## Testing

Build and test with matterbridge:
```
[14:03:41.771] [Lock] Subscribe operatingMode called with: Vacation
[14:03:45.064] [Lock] Subscribe operatingMode called with: Privacy
[14:03:47.653] [Lock] Subscribe operatingMode called with: Passage
[14:03:50.153] [Lock] Subscribe operatingMode called with: NoRemoteLockUnlock
[14:03:51.978] [Lock] Subscribe operatingMode called with: Normal
```
