### PR TITLE
[Tests] Change DoorLock operating mode to NoRemoteLockUnlock

### DIFF
--- a/src/module.test.ts
+++ b/src/module.test.ts
@@ -190,7 +190,7 @@ describe('TestPlatform', () => {
       if (device.hasClusterServer(DoorLockCluster)) {
         await device.executeCommandHandler('lockDoor');
         await device.executeCommandHandler('unlockDoor');
-        await device.setAttribute(DoorLockCluster.id, 'operatingMode', DoorLock.OperatingMode.Vacation);
+        await device.setAttribute(DoorLockCluster.id, 'operatingMode', DoorLock.OperatingMode.NoRemoteLockUnlock);
         await device.setAttribute(DoorLockCluster.id, 'operatingMode', DoorLock.OperatingMode.Normal);
       }
 


### PR DESCRIPTION
`Vacation` mode is NOT supported by default and should be there

**Mandatory modes**

- normal: true → normal mode is supported ✓
- vacation: false → vacation mode is NOT supported
- privacy: false → privacy mode is NOT supported
- noRemoteLockUnlock: true → noRemoteLockUnlock mode is supported ✓ 
- passage: false → passage mode is NOT supported