### PR TITLE
Fix duplicate device registration for thermostat with presets

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1025,8 +1025,6 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
         .addChildDeviceType('Humidity', humiditySensor)
         .createDefaultRelativeHumidityMeasurementClusterServer(50 * 100)
         .addRequiredClusterServers();
-
-      this.thermoAutoPresets = await this.addDevice(this.thermoAutoPresets);
     }
 
     // The cluster attributes are set by MatterbridgeThermostatServer


### PR DESCRIPTION
## Fix duplicate device registration for thermostat with presets

Removed duplicate `addDevice()` call that was causing "Device with name Thermostat (AutoPresets) is already registered" error.

The device was being registered twice:
1. First after initial creation with clusters (line 1011)
2. Again after adding child devices for Flow, Temperature, and Humidity sensors (line 1029)

Child devices are now properly attached to the parent endpoint without re-registering the main device.