### PR TITLE
Fix thermostat device name in preset command test

### DIFF
--- a/src/module.test.ts
+++ b/src/module.test.ts
@@ -258,10 +258,10 @@ describe('TestPlatform', () => {
   });
 
   it('should execute thermostat preset commands and subscriptions', async () => {
-    // Find the Thermostat (AutoPresets) device which has presets
+    // Find the Thermostat (AutoModePresets) device which has presets
     let thermoAutoPreset: MatterbridgeEndpoint | undefined;
     for (const [key, device] of Array.from(dynamicPlatform.bridgedDevices)) {
-      if (device.deviceName === 'Thermostat (AutoPresets)') {
+      if (device.deviceName === 'Thermostat (AutoModePresets)') {
         thermoAutoPreset = device;
         break;
       }


### PR DESCRIPTION
## Summary

This PR fixes a bug in the Jest test for the thermostat with presets that was causing test failures.

**Problem:**
The test `should execute thermostat preset commands and subscriptions` was searching for a device named `'Thermostat (AutoPresets)'`, while the actual device name in the code is `'Thermostat (AutoModePresets)'`. This caused the test to fail with the error `expect(received).toBeDefined() - Received: undefined`.

**Solution:**
Updated the device name in the test to match the actual name used in module.ts (line 1070).

**Impact:**
- ✅ All tests now pass (12/12)
- ✅ Code coverage: 100% functions and lines
- ✅ All 6 Matter preset scenarios (Home, Away, Sleep, Wake, Vacation, GoingToSleep) are properly tested

**Files changed:**
- module.test.ts: Fixed device name in test (2 occurrences)