### PR TITLE
fix: remove Occupancy feature from Presets thermostat example

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1278,7 +1278,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
     this.thermoAutoPresets = new MatterbridgeEndpoint([thermostatDevice, bridgedNode, powerSource], { id: 'Thermostat (AutoModePresets)' }, this.config.debug)
       .createDefaultIdentifyClusterServer()
       .createDefaultBridgedDeviceBasicInformationClusterServer('Thermostat (AutoModePresets)', 'TAP00058', 0xfff1, 'Matterbridge', 'Matterbridge Thermostat With Presets')
-      .createDefaultPresetsThermostatClusterServer(20, 18, 22, 1, 0, 35, 15, 50, 10, 30, false, 20.5, undefined, presets_List, presetTypeDefinitions)
+      .createDefaultPresetsThermostatClusterServer(20, 18, 22, 1, 0, 35, 15, 50, undefined, undefined, undefined, 20.5, undefined, presets_List, presetTypeDefinitions)
       .createDefaultPowerSourceWiredClusterServer()
       .addRequiredClusterServers();
 


### PR DESCRIPTION
The `occupied=false` parameter was incorrectly enabling the `Occupancy` feature, causing preset setpoints to be applied to unoccupied* attributes instead of occupied* attributes, making setpoint subscriptions never trigger.