### PR TITLE
Add example Doorbell device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ If you like this project and find it useful, please consider giving it a star on
 
 ## [3.0.1] - Dev branch
 
+### Added
+
+- [module]: Add example Doorbell device (Identify and MomentarySwitch servers). The Chime client cluster required by the device type is not added yet, since matterbridge doesn't map a client behavior for it.
+
 ### Changed
 
 - [package]: Update dependencies.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 Matterbridge dynamic platform example plugin is a template to develop your own plugin using the dynamic platform.
 
-It exposes 70 virtual devices:
+It exposes 71 virtual devices:
 
 - a door contact sensor
 - a motion sensor
@@ -73,6 +73,7 @@ It exposes 70 virtual devices:
 - an airQuality device with all concentration measurements clusters (supported by Apple Home with the concentration measurements from version 18.5)
 - a momentary switch composed by three switches with Single Double Long (tagged with One Two Three and Top Middle Bottom) and three switches with Single only.
 - a latching switch
+- a doorbell device with a MomentarySwitch cluster (Single press)
 - a Robot Vacuum Cleaner device (supported by SmartThings, Alexa, Home Assistant and partially by Apple Home). Read also <https://github.com/Luligu/matterbridge/discussions/264>.
 - an onOff Mounted Switch device (supported by SmartThings, Alexa, Home Assistant)
 - a onOff Mounted Switch legacy device (supported by all controllers)

--- a/src/module.ts
+++ b/src/module.ts
@@ -34,6 +34,7 @@ import {
   dimmableLight,
   mountedDimmableLoadControl,
   dimmablePlugInUnit,
+  doorbell,
   doorLock,
   electricalSensor,
   extendedColorLight,
@@ -251,6 +252,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
   valve: MatterbridgeEndpoint | undefined;
   momentarySwitch: MatterbridgeEndpoint | undefined;
   latchingSwitch: MatterbridgeEndpoint | undefined;
+  doorbell: MatterbridgeEndpoint | undefined;
   vacuum: MatterbridgeEndpoint | undefined;
   roboticVacuum: MatterbridgeEndpoint | undefined;
   waterHeater: MatterbridgeEndpoint | undefined;
@@ -2054,6 +2056,18 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
 
     this.latchingSwitch = await this.addDevice(this.latchingSwitch);
 
+    // *********************** Create a doorbell *****************************/
+    // The Doorbell device type also requires a Chime client cluster (bound to a separate Chime device to play the sound),
+    // but matterbridge doesn't map a client behavior for the Chime cluster yet, so it is not added here.
+    this.doorbell = new MatterbridgeEndpoint([doorbell, bridgedNode, powerSource], { id: 'Doorbell' }, this.config.debug)
+      .createDefaultBridgedDeviceBasicInformationClusterServer('Doorbell', 'DOB00071', 0xfff1, 'Matterbridge', 'Matterbridge Doorbell')
+      .createDefaultIdentifyClusterServer()
+      .createDefaultMomentarySwitchClusterServer()
+      .createDefaultPowerSourceReplaceableBatteryClusterServer(100, PowerSource.BatChargeLevel.Ok, 3000, 'CR2032', 1)
+      .addRequiredClusterServers();
+
+    this.doorbell = await this.addDevice(this.doorbell);
+
     // *********************** Create a vacuum *****************************
     /*
     The RVC is supported correctly by the Home app (all commands work).
@@ -3235,6 +3249,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
             await this.momentarySwitch?.getChildEndpointById('Momentaryswitch4')?.triggerSwitchEvent('Single', this.momentarySwitch?.log);
             await this.momentarySwitch?.getChildEndpointById('Momentaryswitch5')?.triggerSwitchEvent('Single', this.momentarySwitch?.log);
             await this.momentarySwitch?.getChildEndpointById('Momentaryswitch6')?.triggerSwitchEvent('Single', this.momentarySwitch?.log);
+            await this.doorbell?.triggerSwitchEvent('Single', this.doorbell?.log);
           } else if (this.genericSwitchLastEvent === 'Single') {
             this.genericSwitchLastEvent = 'Double';
             await this.momentarySwitch?.getChildEndpointById('Momentaryswitch1')?.triggerSwitchEvent('Double', this.momentarySwitch?.log);

--- a/vitest/module.test.ts
+++ b/vitest/module.test.ts
@@ -124,7 +124,7 @@ describe('TestPlatform', () => {
     config.blackList = [];
 
     await dynamicPlatform.onStart('Test reason');
-    expect(dynamicPlatform.getDevices()).toHaveLength(70);
+    expect(dynamicPlatform.getDevices()).toHaveLength(71);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'onStart called with reason:', 'Test reason');
     expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.WARN, expect.anything());
     expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.ERROR, expect.anything());
@@ -132,7 +132,7 @@ describe('TestPlatform', () => {
   }, 60000);
 
   it('should execute the commandHandlers', async () => {
-    expect(dynamicPlatform.getDevices()).toHaveLength(70);
+    expect(dynamicPlatform.getDevices()).toHaveLength(71);
     // Invoke command handlers
     for (const device of dynamicPlatform.getDevices()) {
       expect(device).toBeDefined();
@@ -474,7 +474,7 @@ describe('TestPlatform', () => {
 
   it('should call onConfigure', async () => {
     await dynamicPlatform.onConfigure();
-    expect(dynamicPlatform.getDevices()).toHaveLength(70);
+    expect(dynamicPlatform.getDevices()).toHaveLength(71);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'onConfigure called');
 
     await dynamicPlatform.executeIntervals(26, 10);


### PR DESCRIPTION
## Summary
- Add an example `Doorbell` endpoint demonstrating the Matter Doorbell device type (`0x0148`): `Identify` and `Switch` (MomentarySwitch feature) server clusters, wired into the existing periodic switch-event simulation.
- The `Chime` client cluster required by the device type spec is intentionally not added yet, since matterbridge core doesn't currently map a client behavior for the `Chime` cluster (`0x0556`). This is noted in a code comment.
- Update README device list/count and CHANGELOG accordingly.

## Test plan
- [x] `npm run format` / `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run test -- vitest/module.test.ts` passes (14/14), device count updated from 70 to 71
- [x] `npm run test:coverage` shows no coverage regression
