### PR TITLE
Fix inverted heating/cooling setpoints on the Air Conditioner example

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -2370,8 +2370,8 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
     // *********************** Create a airConditioner device ***********************
     this.airConditioner = new AirConditioner('Air Conditioner', 'ACO00027', {
       localTemperature: 20,
-      occupiedCoolingSetpoint: 18,
-      occupiedHeatingSetpoint: 22,
+      occupiedHeatingSetpoint: 18,
+      occupiedCoolingSetpoint: 22,
       fanMode: FanControl.FanMode.Auto,
     })
       .createDefaultTemperatureMeasurementClusterServer(20 * 100)


### PR DESCRIPTION
occupiedHeatingSetpoint (22°C) was configured higher than occupiedCoolingSetpoint (18°C) on the `Air Conditioner` example device, violating the AutoMode deadband invariant from the very first value. Swaps the two so heating sits below cooling, matching the convention already used by the other AutoMode-capable thermostat examples in this file (`Thermostat (AutoMode)`, `Thermostat (AutoOccupancy)`).

A newer `@matter/node` release enforces this invariant more strictly during `setpointRaiseLower` (CHIP `Setpoints::Fix()`-style reconciliation), which surfaced as an intermittent CI failure:

```
Error in reactor<...AirConditioner-ACO00027.thermostat.#assertOccupiedCoolingSetpointChanging>:
Thermostat setpoints could not be reconciled within the configured limits (code 135)
```

Fixes #60

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npx vitest run vitest/module.test.ts` — 14/14 passing, repeated 3x with no flakiness