### PR TITLE
feat(thermostat): add AutoModeSchedules example device (MatterScheduleConfiguration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ If you like this project and find it useful, please consider giving it a star on
 ### Added
 
 - [platform]: Add `closureGarageDoor` device.
+- [thermostat]: Added a thermostat auto mode with schedules (Weekdays and Weekend schedules) including 2 sub endpoints with temperature and humidity sensors, using `createDefaultSchedulesThermostatClusterServer()`.
 
 <a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 Matterbridge dynamic platform example plugin is a template to develop your own plugin using the dynamic platform.
 
-It exposes 72 virtual devices:
+It exposes 73 virtual devices:
 
 - a door contact sensor
 - a motion sensor

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ It exposes 71 virtual devices:
   and relativeHumidityMeasurement cluster (to show how to create a composed device with sub endpoints)
 - a thermostat with auto mode (i.e. with Auto Heat and Cool features), occupancy and outdoorTemperature
 - a thermostat auto mode with presets (Home, Away, Sleep, Wake, Vacation and GoingToSleep modes) including 3 sub endpoints with flow, temperature and humidity sensors
+- a thermostat auto mode with schedules (Weekdays and Weekend schedules) including 2 sub endpoints with temperature and humidity sensors
 - a thermostat heat only with two external temperature sensors (tagged like Indoor and Outdoor)
 - a thermostat cool only
 - a fan with Off High presets

--- a/src/module.ts
+++ b/src/module.ts
@@ -1468,6 +1468,8 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
         name: 'Weekdays',
         transitions: [
           { dayOfWeek: { monday: true, tuesday: true, wednesday: true, thursday: true, friday: true }, transitionTime: 360, heatingSetpoint: 2000, coolingSetpoint: 2400 },
+          { dayOfWeek: { monday: true, tuesday: true, wednesday: true, thursday: true, friday: true }, transitionTime: 750, heatingSetpoint: 1900, coolingSetpoint: 2500 },
+          { dayOfWeek: { monday: true, tuesday: true, wednesday: true, thursday: true, friday: true }, transitionTime: 810, heatingSetpoint: 2000, coolingSetpoint: 2400 },
           { dayOfWeek: { monday: true, tuesday: true, wednesday: true, thursday: true, friday: true }, transitionTime: 1320, heatingSetpoint: 1800, coolingSetpoint: 2600 },
         ],
         builtIn: true,

--- a/src/module.ts
+++ b/src/module.ts
@@ -248,6 +248,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
   thermoAuto: MatterbridgeEndpoint | undefined;
   thermoAutoOccupancy: MatterbridgeEndpoint | undefined;
   thermoAutoPresets: MatterbridgeEndpoint | undefined;
+  thermoAutoSchedules: MatterbridgeEndpoint | undefined;
   thermoHeat: MatterbridgeEndpoint | undefined;
   thermoCool: MatterbridgeEndpoint | undefined;
   fanBase: MatterbridgeEndpoint | undefined;
@@ -1457,6 +1458,139 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
         this.thermoAutoPresets?.log.info(`Subscribe presets called with: ${debugStringify(newValue)} (old value: ${debugStringify(oldValue)})`);
       },
       this.thermoAutoPresets.log,
+    );
+
+    // *********************** Create a thermostat with AutoMode and Schedules device ***********************
+    const schedules_List: Thermostat.Schedule[] = [
+      {
+        scheduleHandle: new Uint8Array([0]),
+        systemMode: Thermostat.SystemMode.Auto,
+        name: 'Weekdays',
+        transitions: [
+          { dayOfWeek: { monday: true, tuesday: true, wednesday: true, thursday: true, friday: true }, transitionTime: 360, heatingSetpoint: 2000, coolingSetpoint: 2400 },
+          { dayOfWeek: { monday: true, tuesday: true, wednesday: true, thursday: true, friday: true }, transitionTime: 1320, heatingSetpoint: 1800, coolingSetpoint: 2600 },
+        ],
+        builtIn: true,
+      },
+      {
+        scheduleHandle: new Uint8Array([1]),
+        systemMode: Thermostat.SystemMode.Auto,
+        name: 'Weekend',
+        transitions: [
+          { dayOfWeek: { saturday: true, sunday: true }, transitionTime: 480, heatingSetpoint: 2100, coolingSetpoint: 2300 },
+          { dayOfWeek: { saturday: true, sunday: true }, transitionTime: 1380, heatingSetpoint: 1900, coolingSetpoint: 2500 },
+        ],
+        builtIn: true,
+      },
+    ];
+
+    const scheduleTypeDefinitions: Thermostat.ScheduleType[] = [
+      {
+        systemMode: Thermostat.SystemMode.Auto,
+        numberOfSchedules: 10,
+        scheduleTypeFeatures: { supportsSetpoints: true, supportsNames: true },
+      },
+    ];
+
+    this.thermoAutoSchedules = new MatterbridgeEndpoint([thermostat, bridgedNode, powerSource], { id: 'Thermostat (AutoModeSchedules)' }, this.config.debug)
+      .createDefaultIdentifyClusterServer()
+      .createDefaultBridgedDeviceBasicInformationClusterServer('Thermostat (AutoModeSchedules)', 'TAS00059', 0xfff1, 'Matterbridge', 'Matterbridge Thermostat With Schedules')
+      .createDefaultSchedulesThermostatClusterServer(
+        20,
+        18,
+        22,
+        1,
+        0,
+        35,
+        15,
+        50,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        null,
+        schedules_List,
+        scheduleTypeDefinitions,
+        10,
+        null,
+      )
+      .createDefaultPowerSourceWiredClusterServer()
+      .addRequiredClusterServers();
+
+    /* v8 ignore next */
+    if (this.thermoAutoSchedules) {
+      this.thermoAutoSchedules
+        .addChildDeviceType('Temperature', temperatureSensor)
+        .createDefaultTemperatureMeasurementClusterServer(21 * 100)
+        .addRequiredClusterServers();
+
+      this.thermoAutoSchedules
+        .addChildDeviceType('Humidity', humiditySensor)
+        .createDefaultRelativeHumidityMeasurementClusterServer(50 * 100)
+        .addRequiredClusterServers();
+
+      this.thermoAutoSchedules = await this.addDevice(this.thermoAutoSchedules);
+    }
+
+    // The cluster attributes are set by MatterbridgeThermostatServer
+    this.thermoAutoSchedules?.addCommandHandler('identify', ({ request: { identifyTime } }) => {
+      this.thermoAutoSchedules?.log.info(`Command identify called identifyTime ${identifyTime}`);
+    });
+    this.thermoAutoSchedules?.addCommandHandler('triggerEffect', ({ request: { effectIdentifier, effectVariant } }) => {
+      this.thermoAutoSchedules?.log.info(`Command identify called effectIdentifier ${effectIdentifier} effectVariant ${effectVariant}`);
+    });
+    this.thermoAutoSchedules?.addCommandHandler('setpointRaiseLower', ({ request: { mode, amount } }) => {
+      const lookupSetpointAdjustMode = ['Heat', 'Cool', 'Both'];
+      this.thermoAutoSchedules?.log.info(`Command setpointRaiseLower called with mode: ${lookupSetpointAdjustMode[mode]} amount: ${amount / 10}`);
+    });
+    // Mirror the Matter SetActiveScheduleRequest command into the activeScheduleHandle attribute
+    this.thermoAutoSchedules?.addCommandHandler('setActiveScheduleRequest', ({ request: { scheduleHandle } }) => {
+      this.thermoAutoSchedules?.log.info(
+        `Command setActiveScheduleRequest called with scheduleHandle: ${scheduleHandle ? `0x${Buffer.from(scheduleHandle).toString('hex')}` : 'null'}`,
+      );
+    });
+    this.thermoAutoSchedules?.subscribeAttribute(
+      Thermostat,
+      'systemMode',
+      (newValue, oldValue) => {
+        const lookupSystemMode = ['Off', 'Auto', '', 'Cool', 'Heat', 'EmergencyHeat', 'Precooling', 'FanOnly', 'Dry', 'Sleep'];
+        this.thermoAutoSchedules?.log.info(`Subscribe systemMode called with: ${lookupSystemMode[newValue]} (old value: ${lookupSystemMode[oldValue]})`);
+      },
+      this.thermoAutoSchedules.log,
+    );
+    this.thermoAutoSchedules?.subscribeAttribute(
+      Thermostat.id,
+      'occupiedHeatingSetpoint',
+      (newValue, oldValue) => {
+        this.thermoAutoSchedules?.log.info(`Subscribe occupiedHeatingSetpoint called with: ${newValue / 100} (old value: ${oldValue / 100})`);
+      },
+      this.thermoAutoSchedules.log,
+    );
+    this.thermoAutoSchedules?.subscribeAttribute(
+      Thermostat.id,
+      'occupiedCoolingSetpoint',
+      (newValue, oldValue) => {
+        this.thermoAutoSchedules?.log.info(`Subscribe occupiedCoolingSetpoint called with: ${newValue / 100} (old value: ${oldValue / 100})`);
+      },
+      this.thermoAutoSchedules.log,
+    );
+    this.thermoAutoSchedules?.subscribeAttribute(
+      Thermostat.id,
+      'activeScheduleHandle',
+      (newValue, oldValue) => {
+        this.thermoAutoSchedules?.log.info(
+          `Subscribe activeScheduleHandle called with: ${newValue ? `0x${Buffer.from(newValue).toString('hex')}` : 'null'} (old value: ${oldValue ? `0x${Buffer.from(oldValue).toString('hex')}` : 'null'})`,
+        );
+      },
+      this.thermoAutoSchedules.log,
+    );
+    this.thermoAutoSchedules?.subscribeAttribute(
+      Thermostat.id,
+      'schedules',
+      (newValue, oldValue) => {
+        this.thermoAutoSchedules?.log.info(`Subscribe schedules called with: ${debugStringify(newValue)} (old value: ${debugStringify(oldValue)})`);
+      },
+      this.thermoAutoSchedules.log,
     );
 
     // *********************** Create a thermostat with Heat device ***********************

--- a/vitest/module.test.ts
+++ b/vitest/module.test.ts
@@ -142,7 +142,7 @@ describe('TestPlatform', () => {
     config.blackList = [];
 
     await dynamicPlatform.onStart('Test reason');
-    expect(dynamicPlatform.getDevices()).toHaveLength(72);
+    expect(dynamicPlatform.getDevices()).toHaveLength(73);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'onStart called with reason:', 'Test reason');
     expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.WARN, expect.anything());
     expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.ERROR, expect.anything());
@@ -150,7 +150,7 @@ describe('TestPlatform', () => {
   }, 60000);
 
   it('should execute the commandHandlers', async () => {
-    expect(dynamicPlatform.getDevices()).toHaveLength(72);
+    expect(dynamicPlatform.getDevices()).toHaveLength(73);
     // Invoke command handlers
     for (const device of dynamicPlatform.getDevices()) {
       expect(device).toBeDefined();
@@ -622,7 +622,7 @@ describe('TestPlatform', () => {
 
   it('should call onConfigure', async () => {
     await dynamicPlatform.onConfigure();
-    expect(dynamicPlatform.getDevices()).toHaveLength(72);
+    expect(dynamicPlatform.getDevices()).toHaveLength(73);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'onConfigure called');
 
     await dynamicPlatform.executeIntervals(26, 10);

--- a/vitest/module.test.ts
+++ b/vitest/module.test.ts
@@ -130,7 +130,7 @@ describe('TestPlatform', () => {
     config.blackList = [];
 
     await dynamicPlatform.onStart('Test reason');
-    expect(dynamicPlatform.getDevices()).toHaveLength(71);
+    expect(dynamicPlatform.getDevices()).toHaveLength(72);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'onStart called with reason:', 'Test reason');
     expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.WARN, expect.anything());
     expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.ERROR, expect.anything());
@@ -138,7 +138,7 @@ describe('TestPlatform', () => {
   }, 60000);
 
   it('should execute the commandHandlers', async () => {
-    expect(dynamicPlatform.getDevices()).toHaveLength(71);
+    expect(dynamicPlatform.getDevices()).toHaveLength(72);
     // Invoke command handlers
     for (const device of dynamicPlatform.getDevices()) {
       expect(device).toBeDefined();
@@ -420,6 +420,47 @@ describe('TestPlatform', () => {
     }
   }, 60000);
 
+  it('should execute thermostat schedule commands and subscriptions', async () => {
+    // Find the Thermostat (AutoModeSchedules) device which has schedules
+    const thermoAutoSchedule = dynamicPlatform.getDeviceByName('Thermostat (AutoModeSchedules)');
+    expect(thermoAutoSchedule).toBeDefined();
+    if (!thermoAutoSchedule) return;
+    expect(thermoAutoSchedule.hasClusterServer(Thermostat.id)).toBe(true);
+
+    // Test setpointRaiseLower command
+    await thermoAutoSchedule.invokeBehaviorCommand('Thermostat', 'setpointRaiseLower', { mode: Thermostat.SetpointRaiseLowerMode.Heat, amount: 100 });
+    await thermoAutoSchedule.invokeBehaviorCommand('Thermostat', 'setpointRaiseLower', { mode: Thermostat.SetpointRaiseLowerMode.Cool, amount: 100 });
+    await thermoAutoSchedule.invokeBehaviorCommand('Thermostat', 'setpointRaiseLower', { mode: Thermostat.SetpointRaiseLowerMode.Both, amount: 100 });
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, expect.stringContaining('Command setpointRaiseLower called'));
+
+    // Test setActiveScheduleRequest command with a valid schedule
+    const scheduleHandle = new Uint8Array([0x00]);
+    await thermoAutoSchedule.invokeBehaviorCommand('Thermostat', 'setActiveScheduleRequest', { scheduleHandle });
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, expect.stringContaining('Command setActiveScheduleRequest called'));
+    expect(thermoAutoSchedule.getAttribute(Thermostat.id, 'activeScheduleHandle')).toEqual(scheduleHandle);
+
+    // Switch to the other valid schedule
+    const otherScheduleHandle = new Uint8Array([0x01]);
+    await thermoAutoSchedule.invokeBehaviorCommand('Thermostat', 'setActiveScheduleRequest', { scheduleHandle: otherScheduleHandle });
+    expect(thermoAutoSchedule.getAttribute(Thermostat.id, 'activeScheduleHandle')).toEqual(otherScheduleHandle);
+
+    // Test setActiveScheduleRequest command with an unknown schedule
+    const invalidScheduleHandle = new Uint8Array([0xff]);
+    await expect(thermoAutoSchedule.invokeBehaviorCommand('Thermostat', 'setActiveScheduleRequest', { scheduleHandle: invalidScheduleHandle })).rejects.toThrow(
+      'Requested ScheduleHandle not found',
+    );
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, expect.stringContaining('Command setActiveScheduleRequest called'));
+    // The unknown schedule request must not corrupt the previously active schedule handle
+    expect(thermoAutoSchedule.getAttribute(Thermostat.id, 'activeScheduleHandle')).toEqual(otherScheduleHandle);
+
+    // Test subscriptions
+    await invokeSubscribeHandler(thermoAutoSchedule, 'Thermostat', 'systemMode', Thermostat.SystemMode.Off, Thermostat.SystemMode.Auto);
+    await invokeSubscribeHandler(thermoAutoSchedule, 'Thermostat', 'occupiedHeatingSetpoint', 2700, 2800);
+    await invokeSubscribeHandler(thermoAutoSchedule, 'Thermostat', 'occupiedCoolingSetpoint', 1400, 1500);
+    await invokeSubscribeHandler(thermoAutoSchedule, 'Thermostat', 'activeScheduleHandle', scheduleHandle, otherScheduleHandle);
+    await invokeSubscribeHandler(thermoAutoSchedule, 'Thermostat', 'schedules', [], []);
+  }, 60000);
+
   it('should execute the remaining thermostat, fan base and air conditioner callbacks', async () => {
     const thermoHeat = dynamicPlatform.getDeviceByName('Thermostat (Heat)');
     const thermoCool = dynamicPlatform.getDeviceByName('Thermostat (Cool)');
@@ -485,7 +526,7 @@ describe('TestPlatform', () => {
 
   it('should call onConfigure', async () => {
     await dynamicPlatform.onConfigure();
-    expect(dynamicPlatform.getDevices()).toHaveLength(71);
+    expect(dynamicPlatform.getDevices()).toHaveLength(72);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'onConfigure called');
 
     await dynamicPlatform.executeIntervals(26, 10);


### PR DESCRIPTION
## Summary
- Adds a new "Thermostat (AutoModeSchedules)" example device demonstrating the `Thermostat.Feature.MatterScheduleConfiguration` support added in matterbridge core (originally proposed in [matterbridge#588](https://github.com/Luligu/matterbridge/pull/588), landed on `dev` as [`bbff8477`](https://github.com/Luligu/matterbridge/commit/bbff84775e935cbc531bab9fa7617d31c39a4fce)), using the new `createDefaultSchedulesThermostatClusterServer()` helper.
- Two built-in schedules (Weekdays, Weekend) with setpoint transitions, plus temperature/humidity sub-endpoints, mirroring the existing AutoModePresets example.
- Mirrors the identify/setpointRaiseLower command handlers and attribute subscriptions used by the presets example, adding a `setActiveScheduleRequest` handler and `activeScheduleHandle`/`schedules` subscriptions.
- Merged in the latest `main` (venetian blind/garage door `Closure` devices, CHIP conformance test tooling, frontend docs), bringing the total example device count to 73.

`matterbridge#588` itself was closed without a GitHub merge, but the schedules helper it introduced is on matterbridge's `dev` branch. Until it ships in a `main`/released build, this plugin's CI is temporarily pinned to build and test against `matterbridge@dev` via `automator.workflow: "dev"` in `package.json` — revert that once the helper is released.

## Diagram

[Attribute map: cluster surface, struct anatomy, the Weekdays/Weekend schedule bitmaps, and the `SetActiveScheduleRequest` command flow](https://claude.ai/code/artifact/093ecd53-2234-48a2-bd51-45be977818d8).

## Test plan
- [x] `npm run build`
- [x] `npm run lint` (oxlint)
- [x] `npm run format -- --check` (oxfmt)
- [x] `npm run typecheck`
- [x] New vitest coverage in `vitest/module.test.ts`: `setActiveScheduleRequest` with valid/invalid schedule handles, attribute subscriptions, device count updated (71 → 72 → 73 after merging `main`)
- [x] Full `npm run test` suite (18/18 passing) and `npm run test:coverage` (100% lines/functions) after merging in `main`
- [x] CI green on all OS/Node combinations, CodeQL and codecov, building against `matterbridge@dev`
