### PR TITLE
feat(thermostat): add ThermostatSuggestions (MSSU) example device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ If you like this project and find it useful, please consider giving it a star on
 
 - [platform]: Add `closureGarageDoor` device.
 - [thermostat]: Added a thermostat auto mode with schedules (Weekdays and Weekend schedules) including 2 sub endpoints with temperature and humidity sensors, using `createDefaultSchedulesThermostatClusterServer()`.
+- [thermostat]: Added a thermostat auto mode with thermostat suggestions (Comfort and Eco presets with a pre-seeded suggestion) including 2 sub endpoints with temperature and humidity sensors, using `createDefaultThermostatSuggestionsClusterServer()`.
 - [chip]: Add chip-test toolchain agents instruction and chip-test runner.
 - [frontend]: Add plugin-frontend agents instructions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ If you like this project and find it useful, please consider giving it a star on
 ### Added
 
 - [platform]: Add `closureGarageDoor` device.
+- [thermostat]: Added a thermostat auto mode with schedules (Weekdays and Weekend schedules) including 2 sub endpoints with temperature and humidity sensors, using `createDefaultSchedulesThermostatClusterServer()`.
 
 <a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ It exposes 71 virtual devices:
   and relativeHumidityMeasurement cluster (to show how to create a composed device with sub endpoints)
 - a thermostat with auto mode (i.e. with Auto Heat and Cool features), occupancy and outdoorTemperature
 - a thermostat auto mode with presets (Home, Away, Sleep, Wake, Vacation and GoingToSleep modes) including 3 sub endpoints with flow, temperature and humidity sensors
+- a thermostat auto mode with schedules (Weekdays and Weekend schedules) including 2 sub endpoints with temperature and humidity sensors
 - a thermostat heat only with two external temperature sensors (tagged like Indoor and Outdoor)
 - a thermostat cool only
 - a fan with Off High presets

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ It exposes 71 virtual devices:
 - a thermostat with auto mode (i.e. with Auto Heat and Cool features), occupancy and outdoorTemperature
 - a thermostat auto mode with presets (Home, Away, Sleep, Wake, Vacation and GoingToSleep modes) including 3 sub endpoints with flow, temperature and humidity sensors
 - a thermostat auto mode with schedules (Weekdays and Weekend schedules) including 2 sub endpoints with temperature and humidity sensors
+- a thermostat auto mode with thermostat suggestions (Comfort and Eco presets with a pre-seeded suggestion) including 2 sub endpoints with temperature and humidity sensors
 - a thermostat heat only with two external temperature sensors (tagged like Indoor and Outdoor)
 - a thermostat cool only
 - a fan with Off High presets

--- a/src/module.ts
+++ b/src/module.ts
@@ -1468,6 +1468,8 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
         name: 'Weekdays',
         transitions: [
           { dayOfWeek: { monday: true, tuesday: true, wednesday: true, thursday: true, friday: true }, transitionTime: 360, heatingSetpoint: 2000, coolingSetpoint: 2400 },
+          { dayOfWeek: { monday: true, tuesday: true, wednesday: true, thursday: true, friday: true }, transitionTime: 750, heatingSetpoint: 1900, coolingSetpoint: 2500 },
+          { dayOfWeek: { monday: true, tuesday: true, wednesday: true, thursday: true, friday: true }, transitionTime: 810, heatingSetpoint: 2000, coolingSetpoint: 2400 },
           { dayOfWeek: { monday: true, tuesday: true, wednesday: true, thursday: true, friday: true }, transitionTime: 1320, heatingSetpoint: 1800, coolingSetpoint: 2600 },
         ],
         builtIn: true,

--- a/src/module.ts
+++ b/src/module.ts
@@ -248,6 +248,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
   thermoAuto: MatterbridgeEndpoint | undefined;
   thermoAutoOccupancy: MatterbridgeEndpoint | undefined;
   thermoAutoPresets: MatterbridgeEndpoint | undefined;
+  thermoAutoSchedules: MatterbridgeEndpoint | undefined;
   thermoHeat: MatterbridgeEndpoint | undefined;
   thermoCool: MatterbridgeEndpoint | undefined;
   fanBase: MatterbridgeEndpoint | undefined;
@@ -1457,6 +1458,139 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
         this.thermoAutoPresets?.log.info(`Subscribe presets called with: ${debugStringify(newValue)} (old value: ${debugStringify(oldValue)})`);
       },
       this.thermoAutoPresets.log,
+    );
+
+    // *********************** Create a thermostat with AutoMode and Schedules device ***********************
+    const schedules_List: Thermostat.Schedule[] = [
+      {
+        scheduleHandle: new Uint8Array([0]),
+        systemMode: Thermostat.SystemMode.Auto,
+        name: 'Weekdays',
+        transitions: [
+          { dayOfWeek: { monday: true, tuesday: true, wednesday: true, thursday: true, friday: true }, transitionTime: 360, heatingSetpoint: 2000, coolingSetpoint: 2400 },
+          { dayOfWeek: { monday: true, tuesday: true, wednesday: true, thursday: true, friday: true }, transitionTime: 1320, heatingSetpoint: 1800, coolingSetpoint: 2600 },
+        ],
+        builtIn: true,
+      },
+      {
+        scheduleHandle: new Uint8Array([1]),
+        systemMode: Thermostat.SystemMode.Auto,
+        name: 'Weekend',
+        transitions: [
+          { dayOfWeek: { saturday: true, sunday: true }, transitionTime: 480, heatingSetpoint: 2100, coolingSetpoint: 2300 },
+          { dayOfWeek: { saturday: true, sunday: true }, transitionTime: 1380, heatingSetpoint: 1900, coolingSetpoint: 2500 },
+        ],
+        builtIn: true,
+      },
+    ];
+
+    const scheduleTypeDefinitions: Thermostat.ScheduleType[] = [
+      {
+        systemMode: Thermostat.SystemMode.Auto,
+        numberOfSchedules: 10,
+        scheduleTypeFeatures: { supportsSetpoints: true, supportsNames: true },
+      },
+    ];
+
+    this.thermoAutoSchedules = new MatterbridgeEndpoint([thermostat, bridgedNode, powerSource], { id: 'Thermostat (AutoModeSchedules)' }, this.config.debug)
+      .createDefaultIdentifyClusterServer()
+      .createDefaultBridgedDeviceBasicInformationClusterServer('Thermostat (AutoModeSchedules)', 'TAS00059', 0xfff1, 'Matterbridge', 'Matterbridge Thermostat With Schedules')
+      .createDefaultSchedulesThermostatClusterServer(
+        20,
+        18,
+        22,
+        1,
+        0,
+        35,
+        15,
+        50,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        null,
+        schedules_List,
+        scheduleTypeDefinitions,
+        10,
+        null,
+      )
+      .createDefaultPowerSourceWiredClusterServer()
+      .addRequiredClusterServers();
+
+    /* v8 ignore next */
+    if (this.thermoAutoSchedules) {
+      this.thermoAutoSchedules
+        .addChildDeviceType('Temperature', temperatureSensor)
+        .createDefaultTemperatureMeasurementClusterServer(21 * 100)
+        .addRequiredClusterServers();
+
+      this.thermoAutoSchedules
+        .addChildDeviceType('Humidity', humiditySensor)
+        .createDefaultRelativeHumidityMeasurementClusterServer(50 * 100)
+        .addRequiredClusterServers();
+
+      this.thermoAutoSchedules = await this.addDevice(this.thermoAutoSchedules);
+    }
+
+    // The cluster attributes are set by MatterbridgeThermostatServer
+    this.thermoAutoSchedules?.addCommandHandler('identify', ({ request: { identifyTime } }) => {
+      this.thermoAutoSchedules?.log.info(`Command identify called identifyTime ${identifyTime}`);
+    });
+    this.thermoAutoSchedules?.addCommandHandler('triggerEffect', ({ request: { effectIdentifier, effectVariant } }) => {
+      this.thermoAutoSchedules?.log.info(`Command identify called effectIdentifier ${effectIdentifier} effectVariant ${effectVariant}`);
+    });
+    this.thermoAutoSchedules?.addCommandHandler('setpointRaiseLower', ({ request: { mode, amount } }) => {
+      const lookupSetpointAdjustMode = ['Heat', 'Cool', 'Both'];
+      this.thermoAutoSchedules?.log.info(`Command setpointRaiseLower called with mode: ${lookupSetpointAdjustMode[mode]} amount: ${amount / 10}`);
+    });
+    // Mirror the Matter SetActiveScheduleRequest command into the activeScheduleHandle attribute
+    this.thermoAutoSchedules?.addCommandHandler('setActiveScheduleRequest', ({ request: { scheduleHandle } }) => {
+      this.thermoAutoSchedules?.log.info(
+        `Command setActiveScheduleRequest called with scheduleHandle: ${scheduleHandle ? `0x${Buffer.from(scheduleHandle).toString('hex')}` : 'null'}`,
+      );
+    });
+    this.thermoAutoSchedules?.subscribeAttribute(
+      Thermostat,
+      'systemMode',
+      (newValue, oldValue) => {
+        const lookupSystemMode = ['Off', 'Auto', '', 'Cool', 'Heat', 'EmergencyHeat', 'Precooling', 'FanOnly', 'Dry', 'Sleep'];
+        this.thermoAutoSchedules?.log.info(`Subscribe systemMode called with: ${lookupSystemMode[newValue]} (old value: ${lookupSystemMode[oldValue]})`);
+      },
+      this.thermoAutoSchedules.log,
+    );
+    this.thermoAutoSchedules?.subscribeAttribute(
+      Thermostat.id,
+      'occupiedHeatingSetpoint',
+      (newValue, oldValue) => {
+        this.thermoAutoSchedules?.log.info(`Subscribe occupiedHeatingSetpoint called with: ${newValue / 100} (old value: ${oldValue / 100})`);
+      },
+      this.thermoAutoSchedules.log,
+    );
+    this.thermoAutoSchedules?.subscribeAttribute(
+      Thermostat.id,
+      'occupiedCoolingSetpoint',
+      (newValue, oldValue) => {
+        this.thermoAutoSchedules?.log.info(`Subscribe occupiedCoolingSetpoint called with: ${newValue / 100} (old value: ${oldValue / 100})`);
+      },
+      this.thermoAutoSchedules.log,
+    );
+    this.thermoAutoSchedules?.subscribeAttribute(
+      Thermostat.id,
+      'activeScheduleHandle',
+      (newValue, oldValue) => {
+        this.thermoAutoSchedules?.log.info(
+          `Subscribe activeScheduleHandle called with: ${newValue ? `0x${Buffer.from(newValue).toString('hex')}` : 'null'} (old value: ${oldValue ? `0x${Buffer.from(oldValue).toString('hex')}` : 'null'})`,
+        );
+      },
+      this.thermoAutoSchedules.log,
+    );
+    this.thermoAutoSchedules?.subscribeAttribute(
+      Thermostat.id,
+      'schedules',
+      (newValue, oldValue) => {
+        this.thermoAutoSchedules?.log.info(`Subscribe schedules called with: ${debugStringify(newValue)} (old value: ${debugStringify(oldValue)})`);
+      },
+      this.thermoAutoSchedules.log,
     );
 
     // *********************** Create a thermostat with Heat device ***********************

--- a/src/module.ts
+++ b/src/module.ts
@@ -248,6 +248,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
   thermoAuto: MatterbridgeEndpoint | undefined;
   thermoAutoOccupancy: MatterbridgeEndpoint | undefined;
   thermoAutoPresets: MatterbridgeEndpoint | undefined;
+  thermoAutoSuggestions: MatterbridgeEndpoint | undefined;
   thermoAutoSchedules: MatterbridgeEndpoint | undefined;
   thermoHeat: MatterbridgeEndpoint | undefined;
   thermoCool: MatterbridgeEndpoint | undefined;
@@ -1458,6 +1459,137 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
         this.thermoAutoPresets?.log.info(`Subscribe presets called with: ${debugStringify(newValue)} (old value: ${debugStringify(oldValue)})`);
       },
       this.thermoAutoPresets.log,
+    );
+
+    // *********************** Create a thermostat with AutoMode and ThermostatSuggestions device ***********************
+    const presets_ListSuggestions: Thermostat.Preset[] = [
+      {
+        presetHandle: new Uint8Array([0]),
+        presetScenario: Thermostat.PresetScenario.Occupied,
+        name: 'Comfort',
+        coolingSetpoint: 2400,
+        heatingSetpoint: 2100,
+        builtIn: true,
+      },
+      {
+        presetHandle: new Uint8Array([1]),
+        presetScenario: Thermostat.PresetScenario.Unoccupied,
+        name: 'Eco',
+        coolingSetpoint: 2700,
+        heatingSetpoint: 1800,
+        builtIn: true,
+      },
+    ];
+
+    const thermostatSuggestions_List: Thermostat.ThermostatSuggestion[] = [
+      {
+        uniqueId: 0,
+        presetHandle: new Uint8Array([1]),
+        effectiveTime: Math.floor(Date.now() / 1000),
+        expirationTime: Math.floor(Date.now() / 1000) + 60 * 60,
+      },
+    ];
+
+    this.thermoAutoSuggestions = new MatterbridgeEndpoint([thermostat, bridgedNode, powerSource], { id: 'Thermostat (AutoModeSuggestions)' }, this.config.debug)
+      .createDefaultIdentifyClusterServer()
+      .createDefaultBridgedDeviceBasicInformationClusterServer('Thermostat (AutoModeSuggestions)', 'TSU00060', 0xfff1, 'Matterbridge', 'Matterbridge Thermostat With Suggestions')
+      .createDefaultThermostatSuggestionsClusterServer(
+        20,
+        18,
+        22,
+        1,
+        0,
+        35,
+        15,
+        50,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        null,
+        presets_ListSuggestions,
+        undefined,
+        thermostatSuggestions_List,
+      )
+      .createDefaultPowerSourceWiredClusterServer()
+      .addRequiredClusterServers();
+
+    /* v8 ignore next */
+    if (this.thermoAutoSuggestions) {
+      this.thermoAutoSuggestions
+        .addChildDeviceType('Temperature', temperatureSensor)
+        .createDefaultTemperatureMeasurementClusterServer(21 * 100)
+        .addRequiredClusterServers();
+
+      this.thermoAutoSuggestions
+        .addChildDeviceType('Humidity', humiditySensor)
+        .createDefaultRelativeHumidityMeasurementClusterServer(50 * 100)
+        .addRequiredClusterServers();
+
+      this.thermoAutoSuggestions = await this.addDevice(this.thermoAutoSuggestions);
+    }
+
+    // The cluster attributes are set by MatterbridgeThermostatServer
+    this.thermoAutoSuggestions?.addCommandHandler('identify', ({ request: { identifyTime } }) => {
+      this.thermoAutoSuggestions?.log.info(`Command identify called identifyTime ${identifyTime}`);
+    });
+    this.thermoAutoSuggestions?.addCommandHandler('triggerEffect', ({ request: { effectIdentifier, effectVariant } }) => {
+      this.thermoAutoSuggestions?.log.info(`Command identify called effectIdentifier ${effectIdentifier} effectVariant ${effectVariant}`);
+    });
+    this.thermoAutoSuggestions?.addCommandHandler('setpointRaiseLower', ({ request: { mode, amount } }) => {
+      const lookupSetpointAdjustMode = ['Heat', 'Cool', 'Both'];
+      this.thermoAutoSuggestions?.log.info(`Command setpointRaiseLower called with mode: ${lookupSetpointAdjustMode[mode]} amount: ${amount / 10}`);
+    });
+    // Mirror the Matter AddThermostatSuggestion command
+    this.thermoAutoSuggestions?.addCommandHandler('addThermostatSuggestion', ({ request: { presetHandle, effectiveTime, expirationInMinutes } }) => {
+      this.thermoAutoSuggestions?.log.info(
+        `Command addThermostatSuggestion called with presetHandle: 0x${Buffer.from(presetHandle).toString('hex')} effectiveTime: ${effectiveTime ?? 'now'} expirationInMinutes: ${expirationInMinutes}`,
+      );
+    });
+    // Mirror the Matter RemoveThermostatSuggestion command
+    this.thermoAutoSuggestions?.addCommandHandler('removeThermostatSuggestion', ({ request: { uniqueId } }) => {
+      this.thermoAutoSuggestions?.log.info(`Command removeThermostatSuggestion called with uniqueId: ${uniqueId}`);
+    });
+    this.thermoAutoSuggestions?.subscribeAttribute(
+      Thermostat,
+      'systemMode',
+      (newValue, oldValue) => {
+        const lookupSystemMode = ['Off', 'Auto', '', 'Cool', 'Heat', 'EmergencyHeat', 'Precooling', 'FanOnly', 'Dry', 'Sleep'];
+        this.thermoAutoSuggestions?.log.info(`Subscribe systemMode called with: ${lookupSystemMode[newValue]} (old value: ${lookupSystemMode[oldValue]})`);
+      },
+      this.thermoAutoSuggestions.log,
+    );
+    this.thermoAutoSuggestions?.subscribeAttribute(
+      Thermostat.id,
+      'occupiedHeatingSetpoint',
+      (newValue, oldValue) => {
+        this.thermoAutoSuggestions?.log.info(`Subscribe occupiedHeatingSetpoint called with: ${newValue / 100} (old value: ${oldValue / 100})`);
+      },
+      this.thermoAutoSuggestions.log,
+    );
+    this.thermoAutoSuggestions?.subscribeAttribute(
+      Thermostat.id,
+      'occupiedCoolingSetpoint',
+      (newValue, oldValue) => {
+        this.thermoAutoSuggestions?.log.info(`Subscribe occupiedCoolingSetpoint called with: ${newValue / 100} (old value: ${oldValue / 100})`);
+      },
+      this.thermoAutoSuggestions.log,
+    );
+    this.thermoAutoSuggestions?.subscribeAttribute(
+      Thermostat.id,
+      'thermostatSuggestions',
+      (newValue, oldValue) => {
+        this.thermoAutoSuggestions?.log.info(`Subscribe thermostatSuggestions called with: ${debugStringify(newValue)} (old value: ${debugStringify(oldValue)})`);
+      },
+      this.thermoAutoSuggestions.log,
+    );
+    this.thermoAutoSuggestions?.subscribeAttribute(
+      Thermostat.id,
+      'currentThermostatSuggestion',
+      (newValue, oldValue) => {
+        this.thermoAutoSuggestions?.log.info(`Subscribe currentThermostatSuggestion called with: ${debugStringify(newValue)} (old value: ${debugStringify(oldValue)})`);
+      },
+      this.thermoAutoSuggestions.log,
     );
 
     // *********************** Create a thermostat with AutoMode and Schedules device ***********************

--- a/vitest/module.test.ts
+++ b/vitest/module.test.ts
@@ -130,7 +130,7 @@ describe('TestPlatform', () => {
     config.blackList = [];
 
     await dynamicPlatform.onStart('Test reason');
-    expect(dynamicPlatform.getDevices()).toHaveLength(71);
+    expect(dynamicPlatform.getDevices()).toHaveLength(72);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'onStart called with reason:', 'Test reason');
     expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.WARN, expect.anything());
     expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.ERROR, expect.anything());
@@ -138,7 +138,7 @@ describe('TestPlatform', () => {
   }, 60000);
 
   it('should execute the commandHandlers', async () => {
-    expect(dynamicPlatform.getDevices()).toHaveLength(71);
+    expect(dynamicPlatform.getDevices()).toHaveLength(72);
     // Invoke command handlers
     for (const device of dynamicPlatform.getDevices()) {
       expect(device).toBeDefined();
@@ -420,6 +420,47 @@ describe('TestPlatform', () => {
     }
   }, 60000);
 
+  it('should execute thermostat schedule commands and subscriptions', async () => {
+    // Find the Thermostat (AutoModeSchedules) device which has schedules
+    const thermoAutoSchedule = dynamicPlatform.getDeviceByName('Thermostat (AutoModeSchedules)');
+    expect(thermoAutoSchedule).toBeDefined();
+    if (!thermoAutoSchedule) return;
+    expect(thermoAutoSchedule.hasClusterServer(Thermostat.id)).toBe(true);
+
+    // Test setpointRaiseLower command
+    await thermoAutoSchedule.invokeBehaviorCommand('Thermostat', 'setpointRaiseLower', { mode: Thermostat.SetpointRaiseLowerMode.Heat, amount: 100 });
+    await thermoAutoSchedule.invokeBehaviorCommand('Thermostat', 'setpointRaiseLower', { mode: Thermostat.SetpointRaiseLowerMode.Cool, amount: 100 });
+    await thermoAutoSchedule.invokeBehaviorCommand('Thermostat', 'setpointRaiseLower', { mode: Thermostat.SetpointRaiseLowerMode.Both, amount: 100 });
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, expect.stringContaining('Command setpointRaiseLower called'));
+
+    // Test setActiveScheduleRequest command with a valid schedule
+    const scheduleHandle = new Uint8Array([0x00]);
+    await thermoAutoSchedule.invokeBehaviorCommand('Thermostat', 'setActiveScheduleRequest', { scheduleHandle });
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, expect.stringContaining('Command setActiveScheduleRequest called'));
+    expect(thermoAutoSchedule.getAttribute(Thermostat.id, 'activeScheduleHandle')).toEqual(scheduleHandle);
+
+    // Switch to the other valid schedule
+    const otherScheduleHandle = new Uint8Array([0x01]);
+    await thermoAutoSchedule.invokeBehaviorCommand('Thermostat', 'setActiveScheduleRequest', { scheduleHandle: otherScheduleHandle });
+    expect(thermoAutoSchedule.getAttribute(Thermostat.id, 'activeScheduleHandle')).toEqual(otherScheduleHandle);
+
+    // Test setActiveScheduleRequest command with an unknown schedule
+    const invalidScheduleHandle = new Uint8Array([0xff]);
+    await expect(thermoAutoSchedule.invokeBehaviorCommand('Thermostat', 'setActiveScheduleRequest', { scheduleHandle: invalidScheduleHandle })).rejects.toThrow(
+      'Requested ScheduleHandle not found',
+    );
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, expect.stringContaining('Command setActiveScheduleRequest called'));
+    // The unknown schedule request must not corrupt the previously active schedule handle
+    expect(thermoAutoSchedule.getAttribute(Thermostat.id, 'activeScheduleHandle')).toEqual(otherScheduleHandle);
+
+    // Test subscriptions
+    await invokeSubscribeHandler(thermoAutoSchedule, 'Thermostat', 'systemMode', Thermostat.SystemMode.Off, Thermostat.SystemMode.Auto);
+    await invokeSubscribeHandler(thermoAutoSchedule, 'Thermostat', 'occupiedHeatingSetpoint', 2700, 2800);
+    await invokeSubscribeHandler(thermoAutoSchedule, 'Thermostat', 'occupiedCoolingSetpoint', 1400, 1500);
+    await invokeSubscribeHandler(thermoAutoSchedule, 'Thermostat', 'activeScheduleHandle', scheduleHandle, otherScheduleHandle);
+    await invokeSubscribeHandler(thermoAutoSchedule, 'Thermostat', 'schedules', [], []);
+  }, 60000);
+
   it('should execute the remaining thermostat, fan base and air conditioner callbacks', async () => {
     const thermoHeat = dynamicPlatform.getDeviceByName('Thermostat (Heat)');
     const thermoCool = dynamicPlatform.getDeviceByName('Thermostat (Cool)');
@@ -485,7 +526,7 @@ describe('TestPlatform', () => {
 
   it('should call onConfigure', async () => {
     await dynamicPlatform.onConfigure();
-    expect(dynamicPlatform.getDevices()).toHaveLength(71);
+    expect(dynamicPlatform.getDevices()).toHaveLength(72);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'onConfigure called');
 
     await dynamicPlatform.executeIntervals(26, 10);

--- a/vitest/module.test.ts
+++ b/vitest/module.test.ts
@@ -130,7 +130,7 @@ describe('TestPlatform', () => {
     config.blackList = [];
 
     await dynamicPlatform.onStart('Test reason');
-    expect(dynamicPlatform.getDevices()).toHaveLength(72);
+    expect(dynamicPlatform.getDevices()).toHaveLength(73);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'onStart called with reason:', 'Test reason');
     expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.WARN, expect.anything());
     expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.ERROR, expect.anything());
@@ -138,7 +138,7 @@ describe('TestPlatform', () => {
   }, 60000);
 
   it('should execute the commandHandlers', async () => {
-    expect(dynamicPlatform.getDevices()).toHaveLength(72);
+    expect(dynamicPlatform.getDevices()).toHaveLength(73);
     // Invoke command handlers
     for (const device of dynamicPlatform.getDevices()) {
       expect(device).toBeDefined();
@@ -420,6 +420,42 @@ describe('TestPlatform', () => {
     }
   }, 60000);
 
+  it('should execute thermostat suggestion commands and subscriptions', async () => {
+    // Find the Thermostat (AutoModeSuggestions) device which has thermostat suggestions
+    const thermoAutoSuggestions = dynamicPlatform.getDeviceByName('Thermostat (AutoModeSuggestions)');
+    expect(thermoAutoSuggestions).toBeDefined();
+    if (!thermoAutoSuggestions) return;
+    expect(thermoAutoSuggestions.hasClusterServer(Thermostat.id)).toBe(true);
+    expect(thermoAutoSuggestions.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(1);
+
+    // Test addThermostatSuggestion command with a valid preset
+    const addRequest = { presetHandle: new Uint8Array([0x00]), effectiveTime: null, expirationInMinutes: 45 };
+    await thermoAutoSuggestions.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', addRequest);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, expect.stringContaining('Command addThermostatSuggestion called'));
+    expect(thermoAutoSuggestions.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(2);
+
+    // Test addThermostatSuggestion command with an unknown preset
+    const invalidAddRequest = { presetHandle: new Uint8Array([0xff]), effectiveTime: null, expirationInMinutes: 45 };
+    await expect(thermoAutoSuggestions.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', invalidAddRequest)).rejects.toThrow('Requested PresetHandle not found');
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, expect.stringContaining('Command addThermostatSuggestion called'));
+
+    // Test removeThermostatSuggestion command with a valid uniqueId
+    await thermoAutoSuggestions.invokeBehaviorCommand('Thermostat', 'removeThermostatSuggestion', { uniqueId: 0 });
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, expect.stringContaining('Command removeThermostatSuggestion called'));
+    expect(thermoAutoSuggestions.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(1);
+
+    // Test removeThermostatSuggestion command with an unknown uniqueId
+    await expect(thermoAutoSuggestions.invokeBehaviorCommand('Thermostat', 'removeThermostatSuggestion', { uniqueId: 99 })).rejects.toThrow('Requested UniqueID not found');
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, expect.stringContaining('Command removeThermostatSuggestion called'));
+
+    // Test subscriptions
+    await invokeSubscribeHandler(thermoAutoSuggestions, 'Thermostat', 'systemMode', Thermostat.SystemMode.Off, Thermostat.SystemMode.Auto);
+    await invokeSubscribeHandler(thermoAutoSuggestions, 'Thermostat', 'occupiedHeatingSetpoint', 2700, 2800);
+    await invokeSubscribeHandler(thermoAutoSuggestions, 'Thermostat', 'occupiedCoolingSetpoint', 1400, 1500);
+    await invokeSubscribeHandler(thermoAutoSuggestions, 'Thermostat', 'thermostatSuggestions', [], []);
+    await invokeSubscribeHandler(thermoAutoSuggestions, 'Thermostat', 'currentThermostatSuggestion', null, null);
+  }, 60000);
+
   it('should execute thermostat schedule commands and subscriptions', async () => {
     // Find the Thermostat (AutoModeSchedules) device which has schedules
     const thermoAutoSchedule = dynamicPlatform.getDeviceByName('Thermostat (AutoModeSchedules)');
@@ -526,7 +562,7 @@ describe('TestPlatform', () => {
 
   it('should call onConfigure', async () => {
     await dynamicPlatform.onConfigure();
-    expect(dynamicPlatform.getDevices()).toHaveLength(72);
+    expect(dynamicPlatform.getDevices()).toHaveLength(73);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'onConfigure called');
 
     await dynamicPlatform.executeIntervals(26, 10);


### PR DESCRIPTION
## Summary

- Adds a **"Thermostat (AutoModeSuggestions)"** device using the new `createDefaultThermostatSuggestionsClusterServer()` helper from [matterbridge PR #593](https://github.com/Luligu/matterbridge/pull/593), mirroring the existing Presets/Schedules examples.
- 2 presets (Comfort/Occupied, Eco/Unoccupied), a pre-seeded suggestion, `addThermostatSuggestion`/`removeThermostatSuggestion` command handlers, `thermostatSuggestions`/`currentThermostatSuggestion` attribute subscriptions, and 2 sub endpoints (temperature and humidity sensors).
- Updated `vitest/module.test.ts` with a dedicated test, `README.md`, and `CHANGELOG.md`.

## Stacking / dependencies

- Stacked on top of #62 (AutoModeSchedules), still open, so this diff includes those commits too until #62 merges. The "Commits" tab shows only the single new commit this PR adds.
- Draft: depends on [matterbridge core PR #593](https://github.com/Luligu/matterbridge/pull/593) (ThermostatSuggestions), which is still open and not merged/released, so this device will not type-check or run until that lands.

