### PR TITLE
Add closureSlidingGate device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ If you like this project and find it useful, please consider giving it a star on
 
 ## [3.0.3] - Dev branch
 
+### Added
+
+- [platform]: Add `closureSlidingGate` device.
+
 <a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
 
 ## [3.0.2] - 2026-08-14

--- a/src/module.ts
+++ b/src/module.ts
@@ -25,7 +25,6 @@
 /* oxlint-disable max-lines */
 /* oxlint-disable max-lines-per-function */
 
-import { ThreeLevelAuto } from '@matter/types/globals';
 import {
   aggregator,
   airPurifier,
@@ -151,6 +150,7 @@ import {
   TotalVolatileOrganicCompoundsConcentrationMeasurement,
   WindowCovering,
 } from 'matterbridge/matter/clusters';
+import { ThreeLevelAuto } from 'matterbridge/matter/types';
 import { fireAndForget, getEnumDescription, isValidBoolean, isValidNumber, isValidObject, isValidString } from 'matterbridge/utils';
 
 /**

--- a/src/module.ts
+++ b/src/module.ts
@@ -227,6 +227,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
   irrigationSystem: IrrigationSystem | undefined;
   closureGarageDoor: Closure | undefined;
   closureVenetianBlind: Closure | undefined;
+  closureSlidingGate: Closure | undefined;
   select: MatterbridgeEndpoint | undefined;
   climate: MatterbridgeEndpoint | undefined;
   switch: MatterbridgeEndpoint | undefined;
@@ -609,6 +610,53 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
     };
     addClosurePanelStepSimulation(closureVenetianBlindLift);
     addClosurePanelStepSimulation(closureVenetianBlindTilt);
+
+    // *********************** Create a sliding gate Closure device ***********************
+    this.closureSlidingGate = new Closure('Sliding Gate', 'GAT000073', {
+      tagList: [getSemtag(ClosureTag.Gate)],
+    });
+
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    this.closureSlidingGate = (await this.addDevice(this.closureSlidingGate)) as Closure | undefined;
+    let closureSlidingGateMoveTimeout: NodeJS.Timeout | undefined;
+
+    // MoveTo is a parent ClosureControl command. Reuses closureTargetToCurrentPosition (declared above for the
+    // garage door), so MoveToPedestrianPosition also gets exercised here (a real driveway gate behavior: a small
+    // pedestrian gap distinct from the fully-open vehicle position).
+    this.closureSlidingGate?.addCommandHandler('ClosureControl.moveTo', ({ request: { position, latch, speed }, attributes }) => {
+      // MatterbridgeClosureControlServer sets the mainState to ClosureControl.MainState.Moving after this call
+      // MatterbridgeClosureControlServer sets the overallTargetState to the requested target state after this call
+      this.closureSlidingGate?.log.info(`Command moveTo called position:${position} latch:${latch} speed:${speed}`);
+      attributes.countdownTime = 1; // We simulate a 1 second movement for demo purposes, so set the countdownTime to 1 second.
+      /* v8 ignore start -- Demo timer simulates closure movement completion. */
+      closureSlidingGateMoveTimeout = setTimeout(() => {
+        const targetState = this.closureSlidingGate?.getAttribute(ClosureControl, 'overallTargetState');
+        if (targetState === undefined || targetState === null || targetState.position === undefined || targetState.position === null) return;
+        void this.closureSlidingGate?.setState(
+          {
+            position: closureTargetToCurrentPosition(targetState.position),
+            latch: targetState.latch,
+            speed: targetState.speed,
+            secureState: targetState.position === ClosureControl.TargetPosition.MoveToFullyClosed && targetState.latch === true,
+          },
+          targetState,
+          ClosureControl.MainState.Stopped,
+          0,
+          [],
+        );
+        void this.closureSlidingGate?.triggerMovementCompleted();
+      }, 1000).unref();
+      /* v8 ignore stop */
+    });
+
+    // Stop is a parent ClosureControl command
+    this.closureSlidingGate?.addCommandHandler('ClosureControl.stop', ({ attributes }) => {
+      // MatterbridgeClosureControlServer sets the mainState to ClosureControl.MainState.Stopped after this call
+      this.closureSlidingGate?.log.info('Command stop called');
+      attributes.countdownTime = 0;
+      clearTimeout(closureSlidingGateMoveTimeout);
+      closureSlidingGateMoveTimeout = undefined;
+    });
 
     // *********************** Create a compound climate device ***********************
     this.climate = new MatterbridgeEndpoint([bridgedNode, powerSource], { id: 'Climate' }, this.config.debug)

--- a/src/module.ts
+++ b/src/module.ts
@@ -25,11 +25,13 @@
 /* oxlint-disable max-lines */
 /* oxlint-disable max-lines-per-function */
 
+import { ThreeLevelAuto } from '@matter/types/globals';
 import {
   aggregator,
   airPurifier,
   airQualitySensor,
   bridgedNode,
+  closure,
   colorTemperatureLight,
   contactSensor,
   windowCovering,
@@ -80,6 +82,7 @@ import {
   IrrigationSystem,
   LaundryDryer,
   LaundryWasher,
+  MatterbridgeClosureControlServer,
   MicrowaveOven,
   Oven,
   Refrigerator,
@@ -227,7 +230,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
   irrigationSystem: IrrigationSystem | undefined;
   closureGarageDoor: Closure | undefined;
   closureVenetianBlind: Closure | undefined;
-  closureSlidingGate: Closure | undefined;
+  closureSlidingGate: MatterbridgeEndpoint | undefined;
   select: MatterbridgeEndpoint | undefined;
   climate: MatterbridgeEndpoint | undefined;
   switch: MatterbridgeEndpoint | undefined;
@@ -612,17 +615,39 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
     addClosurePanelStepSimulation(closureVenetianBlindTilt);
 
     // *********************** Create a sliding gate Closure device ***********************
-    this.closureSlidingGate = new Closure('Sliding Gate', 'GAT000073', {
-      tagList: [getSemtag(ClosureTag.Gate)],
-    });
+    // The Closure single-class device (matterbridge/devices) hard-codes ClosureControl to Positioning +
+    // MotionLatching + Speed only, with no constructor option to add Pedestrian (see
+    // https://github.com/Luligu/matterbridge/issues/609). Build the endpoint the same way Closure itself does
+    // internally (same device types, Identify, BasicInformation and wired PowerSource), but require
+    // MatterbridgeClosureControlServer with the Pedestrian feature added so MoveToPedestrianPosition actually
+    // works instead of being rejected as a ConstraintError — a real driveway gate behavior (a small pedestrian
+    // gap distinct from the fully-open vehicle position).
+    this.closureSlidingGate = new MatterbridgeEndpoint([closure, powerSource], { id: 'SlidingGate-GAT000073', tagList: [getSemtag(ClosureTag.Gate)] }, this.config.debug)
+      .createDefaultIdentifyClusterServer()
+      .createDefaultBasicInformationClusterServer('Sliding Gate', 'GAT000073', 0xfff1, 'Matterbridge', 0x8000, 'Matterbridge Closure')
+      .createDefaultPowerSourceWiredClusterServer();
+    this.closureSlidingGate.behaviors.require(
+      MatterbridgeClosureControlServer.with(
+        ClosureControl.Feature.Positioning,
+        ClosureControl.Feature.MotionLatching,
+        ClosureControl.Feature.Speed,
+        ClosureControl.Feature.Pedestrian,
+      ),
+      {
+        countdownTime: 0,
+        mainState: ClosureControl.MainState.Stopped,
+        currentErrorList: [],
+        overallCurrentState: { position: ClosureControl.CurrentPosition.FullyClosed, latch: true, speed: ThreeLevelAuto.Auto, secureState: true },
+        overallTargetState: { position: ClosureControl.TargetPosition.MoveToFullyClosed, latch: true, speed: ThreeLevelAuto.Auto },
+        latchControlModes: { remoteLatching: true, remoteUnlatching: true },
+      },
+    );
 
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-    this.closureSlidingGate = (await this.addDevice(this.closureSlidingGate)) as Closure | undefined;
+    this.closureSlidingGate = await this.addDevice(this.closureSlidingGate);
     let closureSlidingGateMoveTimeout: NodeJS.Timeout | undefined;
 
     // MoveTo is a parent ClosureControl command. Reuses closureTargetToCurrentPosition (declared above for the
-    // garage door), so MoveToPedestrianPosition also gets exercised here (a real driveway gate behavior: a small
-    // pedestrian gap distinct from the fully-open vehicle position).
+    // garage door), so MoveToPedestrianPosition also gets exercised here.
     this.closureSlidingGate?.addCommandHandler('ClosureControl.moveTo', ({ request: { position, latch, speed }, attributes }) => {
       // MatterbridgeClosureControlServer sets the mainState to ClosureControl.MainState.Moving after this call
       // MatterbridgeClosureControlServer sets the overallTargetState to the requested target state after this call
@@ -630,21 +655,26 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
       attributes.countdownTime = 1; // We simulate a 1 second movement for demo purposes, so set the countdownTime to 1 second.
       /* v8 ignore start -- Demo timer simulates closure movement completion. */
       closureSlidingGateMoveTimeout = setTimeout(() => {
-        const targetState = this.closureSlidingGate?.getAttribute(ClosureControl, 'overallTargetState');
-        if (targetState === undefined || targetState === null || targetState.position === undefined || targetState.position === null) return;
-        void this.closureSlidingGate?.setState(
-          {
-            position: closureTargetToCurrentPosition(targetState.position),
-            latch: targetState.latch,
-            speed: targetState.speed,
-            secureState: targetState.position === ClosureControl.TargetPosition.MoveToFullyClosed && targetState.latch === true,
-          },
-          targetState,
-          ClosureControl.MainState.Stopped,
-          0,
-          [],
-        );
-        void this.closureSlidingGate?.triggerMovementCompleted();
+        void (async (): Promise<void> => {
+          const targetState = this.closureSlidingGate?.getAttribute(ClosureControl, 'overallTargetState');
+          if (targetState === undefined || targetState === null || targetState.position === undefined || targetState.position === null) return;
+          await this.closureSlidingGate?.setAttribute(ClosureControl, 'countdownTime', 0, this.closureSlidingGate.log);
+          await this.closureSlidingGate?.setAttribute(ClosureControl, 'mainState', ClosureControl.MainState.Stopped, this.closureSlidingGate.log);
+          await this.closureSlidingGate?.setAttribute(ClosureControl, 'currentErrorList', [], this.closureSlidingGate.log);
+          await this.closureSlidingGate?.setAttribute(
+            ClosureControl,
+            'overallCurrentState',
+            {
+              position: closureTargetToCurrentPosition(targetState.position),
+              latch: targetState.latch,
+              speed: targetState.speed,
+              secureState: targetState.position === ClosureControl.TargetPosition.MoveToFullyClosed && targetState.latch === true,
+            },
+            this.closureSlidingGate.log,
+          );
+          await this.closureSlidingGate?.setAttribute(ClosureControl, 'overallTargetState', targetState, this.closureSlidingGate.log);
+          await this.closureSlidingGate?.triggerEvent(ClosureControl, 'movementCompleted', undefined, this.closureSlidingGate.log);
+        })();
       }, 1000).unref();
       /* v8 ignore stop */
     });

--- a/vitest/module.test.ts
+++ b/vitest/module.test.ts
@@ -142,7 +142,7 @@ describe('TestPlatform', () => {
     config.blackList = [];
 
     await dynamicPlatform.onStart('Test reason');
-    expect(dynamicPlatform.getDevices()).toHaveLength(74);
+    expect(dynamicPlatform.getDevices()).toHaveLength(75);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'onStart called with reason:', 'Test reason');
     expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.WARN, expect.anything());
     expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.ERROR, expect.anything());
@@ -150,7 +150,7 @@ describe('TestPlatform', () => {
   }, 60000);
 
   it('should execute the commandHandlers', async () => {
-    expect(dynamicPlatform.getDevices()).toHaveLength(74);
+    expect(dynamicPlatform.getDevices()).toHaveLength(75);
     // Invoke command handlers
     for (const device of dynamicPlatform.getDevices()) {
       expect(device).toBeDefined();
@@ -686,7 +686,7 @@ describe('TestPlatform', () => {
 
   it('should call onConfigure', async () => {
     await dynamicPlatform.onConfigure();
-    expect(dynamicPlatform.getDevices()).toHaveLength(74);
+    expect(dynamicPlatform.getDevices()).toHaveLength(75);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'onConfigure called');
 
     await dynamicPlatform.executeIntervals(26, 10);


### PR DESCRIPTION
Closes #65

Adds a third `Closure` example device, a motorized sliding gate (tagged `ClosureTag.Gate`), alongside the existing Garage Door and Venetian Blind examples.

- Modeled on the Garage Door's simple single-panel `ClosureControl` `moveTo`/`stop` flow (no `ClosureDimension` panels).
- Reuses the existing `closureTargetToCurrentPosition` mapping, so `MoveToPedestrianPosition` also gets exercised here. A common real-world driveway gate behavior (small pedestrian gap vs. full vehicle opening) not covered by the other two examples.
- Placed after the Venetian Blind block so the existing chip-test endpoint numbers referenced in `chipTests.json`/`chipTests.md` (17–20, Garage Door / Venetian Blind + panels) are unaffected.

Updated `vitest/module.test.ts` device-count assertions (74 → 75) and `CHANGELOG.md`.

Verified locally: `npm run build`, `npm run lint`, `npm run format:check`, `npm run test`, and `npm run test:coverage` (100% lines/functions) all pass.