### PR TITLE
Add ScheduleLock device: door lock with access schedule features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ If you like this project and find it useful, please consider giving it a star on
 
 ### Added
 
+- [platform]: Add `ScheduleLock` device: a door lock with the User, PinCredential, and optional WeekDayAccessSchedules, YearDayAccessSchedules, and HolidaySchedules features.
 - [platform]: Add `closureSlidingGate` device with pedestrian opening support. Thanks Ludovic BOUÉ.
 - [platform]: Add `closureRoofWindow` device with ventilation opening support. Thanks Ludovic BOUÉ.
 - [devcontainer]: Upgrade the `Dev Container` to v.2.0.0, using the Node.js and Bun stack.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 Matterbridge dynamic platform example plugin is a template to develop your own plugin using the dynamic platform.
 
-It exposes 78 virtual devices:
+It exposes 77 virtual devices:
 
 - a door contact sensor
 - a motion sensor

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 Matterbridge dynamic platform example plugin is a template to develop your own plugin using the dynamic platform.
 
-It exposes 76 virtual devices:
+It exposes 78 virtual devices:
 
 - a door contact sensor
 - a motion sensor
@@ -49,6 +49,8 @@ It exposes 76 virtual devices:
 - a cover with windowCovering cluster and lift feature
 - a cover with windowCovering cluster and both lift and tilt features
 - a lock with doorLock cluster
+- a lock with doorLock cluster and User and PinCredential support (userPinLock)
+- a lock with doorLock cluster, User and PinCredential support, and WeekDay, YearDay and Holiday access schedules (scheduleLock)
 - a thermostat auto mode (i.e. with Auto Heat and Cool features) with thermostat cluster and 3 sub endpoints with flowMeasurement cluster, temperatureMeasurement cluster
   and relativeHumidityMeasurement cluster (to show how to create a composed device with sub endpoints)
 - a thermostat with auto mode (i.e. with Auto Heat and Cool features), occupancy and outdoorTemperature

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "*.schema.json"
   ],
   "automator": {
+    "workflow": "dev",
     "node": true,
     "plugin": true,
     "jest": false,

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "*.schema.json"
   ],
   "automator": {
-    "workflow": "dev",
     "node": true,
     "plugin": true,
     "jest": false,

--- a/src/module.ts
+++ b/src/module.ts
@@ -207,6 +207,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
   coverLiftTilt: MatterbridgeEndpoint | undefined;
   lock: MatterbridgeEndpoint | undefined;
   userPinLock: MatterbridgeEndpoint | undefined;
+  scheduleLock: MatterbridgeEndpoint | undefined;
   thermoAuto: MatterbridgeEndpoint | undefined;
   thermoAutoOccupancy: MatterbridgeEndpoint | undefined;
   thermoAutoPresets: MatterbridgeEndpoint | undefined;
@@ -1276,6 +1277,44 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
         this.userPinLock?.log.info(`Subscribe userCodeTemporaryDisableTime called with: ${value}`);
       },
       this.userPinLock.log,
+    );
+
+    // *********************** Create a lock device with User, Pin and access schedule features ***********************
+    this.scheduleLock = new MatterbridgeEndpoint([doorLock, bridgedNode, powerSource], { id: 'ScheduleLock' }, this.config.debug)
+      .createDefaultIdentifyClusterServer()
+      .createDefaultBridgedDeviceBasicInformationClusterServer('Lock with Schedules', 'LSC00080', 0xfff1, 'Matterbridge', 'Matterbridge Lock')
+      .createUserPinDoorLockClusterServer(DoorLock.LockState.Locked, DoorLock.LockType.DeadBolt, 0, 4, 10, 2, 3, 4)
+      .createDefaultPowerSourceRechargeableBatteryClusterServer(95)
+      .addRequiredClusterServers();
+
+    this.scheduleLock = await this.addDevice(this.scheduleLock);
+
+    // The cluster attributes are set by MatterbridgeDoorLockServer
+    this.scheduleLock?.addCommandHandler('Identify.identify', ({ request: { identifyTime } }) => {
+      this.scheduleLock?.log.info(`Command identify called identifyTime:${identifyTime}`);
+    });
+    this.scheduleLock?.addCommandHandler('DoorLock.lockDoor', () => {
+      this.scheduleLock?.log.info('Command lockDoor called');
+    });
+    this.scheduleLock?.addCommandHandler('DoorLock.unlockDoor', () => {
+      this.scheduleLock?.log.info('Command unlockDoor called');
+    });
+    this.scheduleLock?.addCommandHandler('DoorLock.setWeekDaySchedule', ({ request: { weekDayIndex, userIndex } }) => {
+      this.scheduleLock?.log.info(`Command setWeekDaySchedule called for weekDayIndex:${weekDayIndex} userIndex:${userIndex}`);
+    });
+    this.scheduleLock?.addCommandHandler('DoorLock.setYearDaySchedule', ({ request: { yearDayIndex, userIndex } }) => {
+      this.scheduleLock?.log.info(`Command setYearDaySchedule called for yearDayIndex:${yearDayIndex} userIndex:${userIndex}`);
+    });
+    this.scheduleLock?.addCommandHandler('DoorLock.setHolidaySchedule', ({ request: { holidayIndex } }) => {
+      this.scheduleLock?.log.info(`Command setHolidaySchedule called for holidayIndex:${holidayIndex}`);
+    });
+    this.scheduleLock?.subscribeAttribute(
+      DoorLock,
+      'operatingMode',
+      (value) => {
+        this.scheduleLock?.log.info(`Subscribe operatingMode called with: ${getEnumDescription(DoorLock.OperatingMode, value)}`);
+      },
+      this.scheduleLock.log,
     );
 
     // *********************** Create a thermostat with AutoMode device ***********************
@@ -3282,6 +3321,10 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
         60 * 1000 + 500,
       );
     }
+
+    // Set schedule lock to Locked
+    await this.scheduleLock?.setAttribute(DoorLock.id, 'lockState', DoorLock.LockState.Locked, this.scheduleLock.log);
+    this.scheduleLock?.log.info('Set schedule lock initial lockState to Locked');
 
     // Set local to 16°C
     await this.thermoAuto?.setAttribute(Thermostat.id, 'localTemperature', 16 * 100, this.thermoAuto.log);

--- a/vitest/module.test.ts
+++ b/vitest/module.test.ts
@@ -143,7 +143,7 @@ describe('TestPlatform', () => {
     config.blackList = [];
 
     await dynamicPlatform.onStart('Test reason');
-    expect(dynamicPlatform.getDevices()).toHaveLength(76);
+    expect(dynamicPlatform.getDevices()).toHaveLength(77);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'onStart called with reason:', 'Test reason');
     expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.WARN, expect.anything());
     expect(loggerLogSpy).not.toHaveBeenCalledWith(LogLevel.ERROR, expect.anything());
@@ -151,7 +151,7 @@ describe('TestPlatform', () => {
   }, 60000);
 
   it('should execute the commandHandlers', async () => {
-    expect(dynamicPlatform.getDevices()).toHaveLength(76);
+    expect(dynamicPlatform.getDevices()).toHaveLength(77);
     const percentSettingSubscribers = new Set([dynamicPlatform.airPurifier, dynamicPlatform.fanDefault, dynamicPlatform.fanComplete, dynamicPlatform.airConditioner]);
     // Invoke command handlers
     for (const device of dynamicPlatform.getDevices()) {
@@ -312,6 +312,39 @@ describe('TestPlatform', () => {
         await device.setAttribute(DoorLock, 'operatingMode', DoorLock.OperatingMode.Normal);
         await device.setAttribute(DoorLock, 'wrongCodeEntryLimit', 3);
         await device.setAttribute(DoorLock, 'userCodeTemporaryDisableTime', 30);
+      }
+      if (device.id === 'ScheduleLock') {
+        await device.invokeBehaviorCommand(DoorLock, 'setUser', {
+          operationType: DoorLock.DataOperationType.Add,
+          userIndex: 1,
+          userName: 'Scheduled User',
+          userUniqueId: 100,
+          userStatus: DoorLock.UserStatus.OccupiedEnabled,
+          userType: DoorLock.UserType.ScheduleRestrictedUser,
+          credentialRule: DoorLock.CredentialRule.Single,
+        });
+        await device.invokeBehaviorCommand(DoorLock, 'setWeekDaySchedule', {
+          weekDayIndex: 1,
+          userIndex: 1,
+          daysMask: new DoorLock.DaysMask({ monday: true }),
+          startHour: 8,
+          startMinute: 30,
+          endHour: 17,
+          endMinute: 30,
+        });
+        await device.invokeBehaviorCommand(DoorLock, 'getWeekDaySchedule', { weekDayIndex: 1, userIndex: 1 });
+        await device.invokeBehaviorCommand(DoorLock, 'clearWeekDaySchedule', { weekDayIndex: 1, userIndex: 1 });
+        await device.invokeBehaviorCommand(DoorLock, 'setYearDaySchedule', { yearDayIndex: 1, userIndex: 1, localStartTime: 1_000, localEndTime: 2_000 });
+        await device.invokeBehaviorCommand(DoorLock, 'getYearDaySchedule', { yearDayIndex: 1, userIndex: 1 });
+        await device.invokeBehaviorCommand(DoorLock, 'clearYearDaySchedule', { yearDayIndex: 1, userIndex: 1 });
+        await device.invokeBehaviorCommand(DoorLock, 'setHolidaySchedule', {
+          holidayIndex: 1,
+          localStartTime: 3_000,
+          localEndTime: 4_000,
+          operatingMode: DoorLock.OperatingMode.Vacation,
+        });
+        await device.invokeBehaviorCommand(DoorLock, 'getHolidaySchedule', { holidayIndex: 1 });
+        await device.invokeBehaviorCommand(DoorLock, 'clearHolidaySchedule', { holidayIndex: 1 });
       }
 
       if (device.hasClusterServer(FanControl)) {
@@ -801,7 +834,7 @@ describe('TestPlatform', () => {
 
   it('should call onConfigure', async () => {
     await dynamicPlatform.onConfigure();
-    expect(dynamicPlatform.getDevices()).toHaveLength(76);
+    expect(dynamicPlatform.getDevices()).toHaveLength(77);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, 'onConfigure called');
 
     await dynamicPlatform.executeIntervals(26, 10);


### PR DESCRIPTION
## Summary

- Adds a `ScheduleLock` door lock device demonstrating the optional access schedule features (`WeekDayAccessSchedules`, `YearDayAccessSchedules`, `HolidaySchedules`) added to `createUserPinDoorLockClusterServer()`, alongside the existing `Lock` and `UserPinLock` devices.
- Wires command handlers for `setWeekDaySchedule`, `setYearDaySchedule`, and `setHolidaySchedule` for logging, matching the existing pattern for `lockDoor`/`unlockDoor`.
- Extends the device test loop to exercise `setUser`, `setWeekDaySchedule`/`getWeekDaySchedule`/`clearWeekDaySchedule`, `setYearDaySchedule`/`getYearDaySchedule`/`clearYearDaySchedule`, and `setHolidaySchedule`/`getHolidaySchedule`/`clearHolidaySchedule`.

## Dependency

This required matching `matterbridge` library support for the optional access schedule features (schedule parameters on `createDefaultDoorLockClusterServer()` / `createUserPinDoorLockClusterServer()`, and the corresponding command forwarding in `MatterbridgeDoorLockServer`). That support is now available on `matterbridge` `dev`, added by Luligu in [`63c90e9`](https://github.com/Luligu/matterbridge/commit/63c90e92961e349f74a6333dc44c2f59330ad4f4) ("Add DoorLock chip tests", see [PR #613 comment](https://github.com/Luligu/matterbridge/pull/613#issuecomment-5455089055)), which also adds the DoorLock chip test coverage. This PR can leave draft once a `matterbridge` release containing that commit is published.

## Test plan

- `npm run build` — clean.
- `npx oxfmt --check` / `npx oxlint` — clean.
- `npx vitest run vitest/module.test.ts` — 18/19 pass. The one failure (`should execute the remaining thermostat, fan base and air conditioner callbacks`, an unrelated `FanControl.percentSetting` assertion) reproduces identically on `main` with none of this PR's changes applied, so it's a pre-existing issue, not a regression from this change.
