### PR TITLE
fix(closure): opt in to MotionLatching for Garage Door and Venetian Blind

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "*.schema.json"
   ],
   "automator": {
+    "workflow": "dev",
     "node": true,
     "plugin": true,
     "jest": false,

--- a/src/module.ts
+++ b/src/module.ts
@@ -493,10 +493,9 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
     // *********************** Create a venetian blind Closure device with Lift and Tilt panels ***********************
     this.closureVenetianBlind = new Closure('Venetian Blind', 'VEN000072', {
       tagList: [getSemtag(ClosureTag.Covering), getSemtag(ClosureCoveringTag.Venetian)],
-      motionLatching: true,
     });
-    const closureVenetianBlindLift = this.closureVenetianBlind.addPanel('Lift', [getSemtag(ClosurePanelTag.Lift)], 'lift', { motionLatching: true });
-    const closureVenetianBlindTilt = this.closureVenetianBlind.addPanel('Tilt', [getSemtag(ClosurePanelTag.Tilt)], 'tilt', { motionLatching: true });
+    const closureVenetianBlindLift = this.closureVenetianBlind.addPanel('Lift', [getSemtag(ClosurePanelTag.Lift)], 'lift');
+    const closureVenetianBlindTilt = this.closureVenetianBlind.addPanel('Tilt', [getSemtag(ClosurePanelTag.Tilt)], 'tilt');
 
     this.closureVenetianBlind = await this.addDevice(this.closureVenetianBlind);
 
@@ -542,10 +541,12 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
             : ClosureControl.CurrentPosition.PartiallyOpened;
 
       void this.closureVenetianBlind?.setAttribute(ClosureControl, 'mainState', ClosureControl.MainState.Stopped, this.closureVenetianBlind.log);
+      // The Venetian Blind does not support MotionLatching (a blind has no latch/lock, unlike a gate or garage door),
+      // so secureState mirrors the fully-closed position instead of a latch state.
       void this.closureVenetianBlind?.setAttribute(
         ClosureControl,
         'overallCurrentState',
-        { position: overallPosition, latch: liftCurrent.latch ?? true, speed: liftCurrent.speed, secureState: liftCurrent.position === 10000 && liftCurrent.latch === true },
+        { position: overallPosition, speed: liftCurrent.speed, secureState: overallPosition === ClosureControl.CurrentPosition.FullyClosed },
         this.closureVenetianBlind?.log,
       );
     };
@@ -569,14 +570,8 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
 
     // Parent MoveTo drives the child panels by mirroring the resolved overall target into each panel's targetState.
     // Direct controller commands to a panel still arrive through ClosureDimension.setTarget below.
-    const moveClosurePanelTo = (
-      panel: MatterbridgeEndpoint,
-      position: number,
-      latch: ClosureControl.OverallTargetState['latch'],
-      speed: ClosureControl.OverallTargetState['speed'],
-    ): void => {
-      // v8 ignore next -- latch here is always defined
-      void panel.setAttribute(ClosureDimension, 'targetState', { position, latch: latch ?? true, speed }, panel.log);
+    const moveClosurePanelTo = (panel: MatterbridgeEndpoint, position: number, speed: ClosureControl.OverallTargetState['speed']): void => {
+      void panel.setAttribute(ClosureDimension, 'targetState', { position, speed }, panel.log);
       simulateClosurePanelReachingTarget(panel);
     };
 
@@ -592,8 +587,8 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
         const targetState = this.closureVenetianBlind?.getAttribute(ClosureControl, 'overallTargetState');
         if (targetState === undefined || targetState === null || targetState.position === undefined || targetState.position === null) return;
         const panelPercent = closurePanelTargetPercent(targetState.position);
-        moveClosurePanelTo(closureVenetianBlindLift, panelPercent, targetState.latch, targetState.speed);
-        moveClosurePanelTo(closureVenetianBlindTilt, panelPercent, targetState.latch, targetState.speed);
+        moveClosurePanelTo(closureVenetianBlindLift, panelPercent, targetState.speed);
+        moveClosurePanelTo(closureVenetianBlindTilt, panelPercent, targetState.speed);
       }, 1000).unref();
       /* v8 ignore stop */
     });

--- a/src/module.ts
+++ b/src/module.ts
@@ -434,6 +434,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
     // *********************** Create a garage door Closure device ***********************
     this.closureGarageDoor = new Closure('Garage Door', 'GAR000071', {
       tagList: [getSemtag(ClosureTag.GarageDoor)],
+      motionLatching: true,
     });
 
     this.closureGarageDoor = await this.addDevice(this.closureGarageDoor);
@@ -492,9 +493,10 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
     // *********************** Create a venetian blind Closure device with Lift and Tilt panels ***********************
     this.closureVenetianBlind = new Closure('Venetian Blind', 'VEN000072', {
       tagList: [getSemtag(ClosureTag.Covering), getSemtag(ClosureCoveringTag.Venetian)],
+      motionLatching: true,
     });
-    const closureVenetianBlindLift = this.closureVenetianBlind.addPanel('Lift', [getSemtag(ClosurePanelTag.Lift)], 'lift');
-    const closureVenetianBlindTilt = this.closureVenetianBlind.addPanel('Tilt', [getSemtag(ClosurePanelTag.Tilt)], 'tilt');
+    const closureVenetianBlindLift = this.closureVenetianBlind.addPanel('Lift', [getSemtag(ClosurePanelTag.Lift)], 'lift', { motionLatching: true });
+    const closureVenetianBlindTilt = this.closureVenetianBlind.addPanel('Tilt', [getSemtag(ClosurePanelTag.Tilt)], 'tilt', { motionLatching: true });
 
     this.closureVenetianBlind = await this.addDevice(this.closureVenetianBlind);
 

--- a/vitest/module.test.ts
+++ b/vitest/module.test.ts
@@ -252,19 +252,32 @@ describe('TestPlatform', () => {
       }
 
       if (device.hasClusterServer(ClosureControl)) {
-        // oxlint-disable-next-line vitest/no-conditional-expect
-        await expect(
-          device.invokeBehaviorCommand('closureControl', 'ClosureControl.moveTo', { position: ClosureControl.TargetPosition.MoveToFullyClosed, latch: true }),
-        ).rejects.toThrow('ClosureControl.moveTo position changes require latch false while the closure is latched');
-        await device.invokeBehaviorCommand('closureControl', 'ClosureControl.moveTo', { position: ClosureControl.TargetPosition.MoveToSignaturePosition, latch: false });
-        await device.invokeBehaviorCommand('closureControl', 'ClosureControl.moveTo', { position: ClosureControl.TargetPosition.MoveToFullyOpen, latch: false });
+        const closureControlFeatures = featuresFor(device, ClosureControl);
+
+        if (closureControlFeatures.motionLatching) {
+          // oxlint-disable-next-line vitest/no-conditional-expect
+          await expect(
+            device.invokeBehaviorCommand('closureControl', 'ClosureControl.moveTo', { position: ClosureControl.TargetPosition.MoveToFullyClosed, latch: true }),
+          ).rejects.toThrow('ClosureControl.moveTo position changes require latch false while the closure is latched');
+          await device.invokeBehaviorCommand('closureControl', 'ClosureControl.moveTo', { position: ClosureControl.TargetPosition.MoveToSignaturePosition, latch: false });
+          await device.invokeBehaviorCommand('closureControl', 'ClosureControl.moveTo', { position: ClosureControl.TargetPosition.MoveToFullyOpen, latch: false });
+        } else {
+          await device.invokeBehaviorCommand('closureControl', 'ClosureControl.moveTo', { position: ClosureControl.TargetPosition.MoveToSignaturePosition });
+          await device.invokeBehaviorCommand('closureControl', 'ClosureControl.moveTo', { position: ClosureControl.TargetPosition.MoveToFullyOpen });
+        }
         await device.invokeBehaviorCommand('closureControl', 'ClosureControl.stop', {});
         for (const panel of device.getChildEndpoints()) {
           if (panel.hasClusterServer(ClosureDimension)) {
-            await panel.invokeBehaviorCommand('closureDimension', 'ClosureDimension.setTarget', { position: 5000, latch: false });
-            // Step is only allowed while unlatched (Matter spec §5.5.8.2.4); force the state so the handler under test runs.
-            const panelCurrentState = panel.getAttribute(ClosureDimension, 'currentState');
-            await panel.setAttribute(ClosureDimension, 'currentState', { position: panelCurrentState?.position, latch: false, speed: panelCurrentState?.speed });
+            const closureDimensionFeatures = featuresFor(panel, ClosureDimension);
+
+            if (closureDimensionFeatures.motionLatching) {
+              await panel.invokeBehaviorCommand('closureDimension', 'ClosureDimension.setTarget', { position: 5000, latch: false });
+              // Step is only allowed while unlatched (Matter spec §5.5.8.2.4); force the state so the handler under test runs.
+              const panelCurrentState = panel.getAttribute(ClosureDimension, 'currentState');
+              await panel.setAttribute(ClosureDimension, 'currentState', { position: panelCurrentState?.position, latch: false, speed: panelCurrentState?.speed });
+            } else {
+              await panel.invokeBehaviorCommand('closureDimension', 'ClosureDimension.setTarget', { position: 5000 });
+            }
             await panel.invokeBehaviorCommand('closureDimension', 'ClosureDimension.step', { direction: ClosureDimension.StepDirection.Increase, numberOfSteps: 1 });
           }
         }


### PR DESCRIPTION
## Summary

`matterbridge` `dev` made the `ClosureControl`/`ClosureDimension` MotionLatching feature opt-in via a new `motionLatching` option on `ClosureOptions`/`ClosurePanelOptions` (previously it was always enabled). See:

- `matterbridge` CHANGELOG `[3.10.8] - Dev branch`:
  - `[closureControl]: Add motionLatching and speed options to ClosureOptions to opt in to the optional MotionLatching and Speed features.`
  - `[closureDimension]: Add motionLatching and speed options to ClosurePanelOptions to opt in to the optional MotionLatching and Speed features per panel.`

The Garage Door and Venetian Blind demo devices in this plugin already read/write the `latch` field unconditionally (command handlers, sync helpers) but never opted in, so:

- Writing `latch` on `ClosureControl.overallCurrentState`/`overallTargetState` and `ClosureDimension.targetState`/`currentState` now fails with `Conformance "LT": Matter does not allow you to set this attribute`.
- The shared `should execute the commandHandlers` test's unconditional latch-rejection assertion (`ClosureControl.moveTo position changes require latch false while the closure is latched`) stopped firing for these devices.

## Fix

`MotionLatching` models a physical latch/lock. That fits a garage door or a gate, not a venetian blind (which only moves between lift/tilt positions and has no latch mechanism), so the fix is device-specific rather than a blanket opt-in:

- **Garage Door**: pass `motionLatching: true` to the `Closure` constructor (it already read/wrote `latch` unconditionally, matching the intent).
- **Venetian Blind**: keep `MotionLatching` disabled. Drop the now-unsupported `latch` reads/writes from its `moveTo` sync helper (`syncClosureVenetianBlindFromPanels`) and from `moveClosurePanelTo`; `secureState` now mirrors the fully-closed position instead of a latch state, matching `MatterbridgeClosureControlServer`'s own default `secureState` logic for closures without `MotionLatching`.
- **Sliding Gate**: unaffected — it already declares `ClosureControl.Feature.MotionLatching` explicitly via `MatterbridgeClosureControlServer.with(...)`.
- **`vitest/module.test.ts`**: the shared `should execute the commandHandlers` test unconditionally exercised the latch-rejection behavior for every device with `ClosureControl`/`ClosureDimension`, regardless of whether the device actually supports `MotionLatching`. Gated those assertions on `featuresFor(device, ClosureControl).motionLatching` / `featuresFor(panel, ClosureDimension).motionLatching`, matching the pattern already used elsewhere in the same test for `OnOff`/`ColorControl`/`WindowCovering`/`FanControl`/`Thermostat`.

## Dependency

Like [#68](https://github.com/Luligu/matterbridge-example-dynamic-platform/pull/68), this requires the `motionLatching` option, which is only on `matterbridge` `dev` (not yet released). Set `automator.workflow` to `"dev"` so CI builds against that branch, same as #68.

## Test plan

- `npm run build` — clean.
- `npx oxfmt --check` / `npx oxlint` — clean.
- `npx vitest run vitest/module.test.ts` — 23/23 pass (previously 3 failing: `should execute the commandHandlers`, `should resolve the venetian blind panel target percent for every moveTo position`, `should stop the venetian blind without completing pending panel movement`).
