### PR TITLE
Feature/temperature alarm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ If you like this project and find it useful, please consider giving it a star on
 
 - [matterbridge]: Require matterbridge v.3.10.8 with matter v.1.6.0.
 
+### Added
+
+- [Oven]/[Refrigerator]: Add a `TemperatureAlarm` example to the demo cabinets: `criticalOverTemperatureThreshold` on the Oven's Upper Cabinet, `criticalUnderTemperatureThreshold` on the Refrigerator's Freezer Bottom cabinet. Requires the matterbridge `TemperatureAlarm` support (not yet released).
+
 <a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
 
 ## [3.0.3] - 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ If you like this project and find it useful, please consider giving it a star on
 
 ### Added
 
-- [Oven]/[Refrigerator]: Add a `TemperatureAlarm` example to the demo cabinets: `criticalOverTemperatureThreshold` on the Oven's Upper Cabinet, `criticalUnderTemperatureThreshold` on the Refrigerator's Freezer Bottom cabinet. Requires the matterbridge `TemperatureAlarm` support (not yet released).
+- [Oven]/[Refrigerator]: Add a `TemperatureAlarm` example to the demo cabinets.
 
 <a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -3005,9 +3005,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
             await freezer?.setAttribute('TemperatureMeasurement', 'measuredValue', -1000, freezer.log);
           }
           if (this.phase === 1) await this.refrigerator.setDoorOpenState(true);
-          if (this.phase === 2) await this.refrigerator.triggerDoorOpenState(true);
           if (this.phase === 4) await this.refrigerator.setDoorOpenState(false);
-          if (this.phase === 4) await this.refrigerator.triggerDoorOpenState(false);
           if (this.phase === 5) {
             const refrigerator = this.refrigerator.getChildEndpointById('RefrigeratorTop');
             // 1 Auto 2 RapidCool
@@ -3022,9 +3020,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
             await freezer?.setAttribute('TemperatureMeasurement', 'measuredValue', -1500, freezer.log);
           }
           if (this.phase === 6) await this.refrigerator.setDoorOpenState(true);
-          if (this.phase === 7) await this.refrigerator.triggerDoorOpenState(true);
           if (this.phase === 9) await this.refrigerator.setDoorOpenState(false);
-          if (this.phase === 9) await this.refrigerator.triggerDoorOpenState(false);
         }
         this.phase += 1;
         this.phase = this.phase >= 10 ? 0 : this.phase;

--- a/src/module.ts
+++ b/src/module.ts
@@ -2604,8 +2604,8 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
       phaseList: ['pre-heating', 'pre-heated', 'cooling down'],
     });
     // Enable the TemperatureAlarm OverTemperature feature directly on the cabinet endpoint.
-    ovenUpperCabinet.createDefaultTemperatureAlarmClusterServer(280 * 100);
-    this.oven.addCabinet('Lower Cabinet', {
+    ovenUpperCabinet.createDefaultTemperatureAlarmClusterServer(280_00);
+    const ovenLowerCabinet = this.oven.addCabinet('Lower Cabinet', {
       tagList: [{ mfgCode: null, namespaceId: CommonPositionTag.Bottom.namespaceId, tag: CommonPositionTag.Bottom.tag, label: CommonPositionTag.Bottom.label }],
       currentMode: 3,
       supportedModes: [
@@ -2622,6 +2622,8 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
       currentPhase: 1,
       phaseList: ['pre-heating', 'pre-heated', 'cooling down'],
     });
+    // Enable the TemperatureAlarm OverTemperature feature directly on the cabinet endpoint.
+    ovenLowerCabinet.createDefaultTemperatureAlarmClusterServer(280_00);
     this.oven = await this.addDevice(this.oven);
 
     // *********************** Create an Cooktop **************************
@@ -2654,7 +2656,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
 
     // *********************** Create an Refrigerator **************************
     const refrigerator = new Refrigerator('Refrigerator', 'REF00056');
-    refrigerator.addCabinet('Refrigerator Top', {
+    const refrigeratorTopCabinet = refrigerator.addCabinet('Refrigerator Top', {
       tagList: [
         { mfgCode: null, namespaceId: CommonPositionTag.Top.namespaceId, tag: CommonPositionTag.Top.tag, label: 'Refrigerator Top' },
         { mfgCode: null, namespaceId: RefrigeratorTag.Refrigerator.namespaceId, tag: RefrigeratorTag.Refrigerator.tag, label: RefrigeratorTag.Refrigerator.label },
@@ -2665,19 +2667,21 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
       step: 1 * 100,
       currentTemperature: 1200,
     });
+    // Enable the TemperatureAlarm UnderTemperature feature directly on the cabinet endpoint.
+    refrigeratorTopCabinet.createDefaultTemperatureAlarmClusterServer(20_00, 5_00);
     const freezerBottomCabinet = refrigerator.addCabinet('Freezer Bottom', {
       tagList: [
         { mfgCode: null, namespaceId: CommonPositionTag.Bottom.namespaceId, tag: CommonPositionTag.Bottom.tag, label: 'Freezer Bottom' },
         { mfgCode: null, namespaceId: RefrigeratorTag.Freezer.namespaceId, tag: RefrigeratorTag.Freezer.tag, label: RefrigeratorTag.Freezer.label },
       ],
       targetTemperature: -18 * 100,
-      minTemperature: -30 * 100,
+      minTemperature: -25 * 100,
       maxTemperature: -10 * 100,
       step: 1 * 100,
       currentTemperature: -1800,
     });
     // Enable the TemperatureAlarm UnderTemperature feature directly on the cabinet endpoint.
-    freezerBottomCabinet.createDefaultTemperatureAlarmClusterServer(undefined, -25 * 100);
+    freezerBottomCabinet.createDefaultTemperatureAlarmClusterServer(-5_00, -30_00);
     this.refrigerator = await this.addDevice(refrigerator);
 
     // *********************** Create a airConditioner device ***********************
@@ -3005,7 +3009,9 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
             await freezer?.setAttribute('TemperatureMeasurement', 'measuredValue', -1000, freezer.log);
           }
           if (this.phase === 1) await this.refrigerator.setDoorOpenState(true);
+          if (this.phase === 2) await this.refrigerator.triggerDoorOpenState(true);
           if (this.phase === 4) await this.refrigerator.setDoorOpenState(false);
+          if (this.phase === 4) await this.refrigerator.triggerDoorOpenState(false);
           if (this.phase === 5) {
             const refrigerator = this.refrigerator.getChildEndpointById('RefrigeratorTop');
             // 1 Auto 2 RapidCool
@@ -3020,7 +3026,9 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
             await freezer?.setAttribute('TemperatureMeasurement', 'measuredValue', -1500, freezer.log);
           }
           if (this.phase === 6) await this.refrigerator.setDoorOpenState(true);
+          if (this.phase === 7) await this.refrigerator.triggerDoorOpenState(true);
           if (this.phase === 9) await this.refrigerator.setDoorOpenState(false);
+          if (this.phase === 9) await this.refrigerator.triggerDoorOpenState(false);
         }
         this.phase += 1;
         this.phase = this.phase >= 10 ? 0 : this.phase;

--- a/src/module.ts
+++ b/src/module.ts
@@ -2579,7 +2579,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
 
     // *********************** Create an Oven **************************
     this.oven = new Oven('Oven', 'OVN00054');
-    this.oven.addCabinet('Upper Cabinet', {
+    const ovenUpperCabinet = this.oven.addCabinet('Upper Cabinet', {
       tagList: [{ mfgCode: null, namespaceId: CommonPositionTag.Top.namespaceId, tag: CommonPositionTag.Top.tag, label: CommonPositionTag.Top.label }],
       currentMode: 2,
       supportedModes: [
@@ -2602,8 +2602,9 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
       operationalState: OperationalState.OperationalStateEnum.Stopped,
       currentPhase: 2,
       phaseList: ['pre-heating', 'pre-heated', 'cooling down'],
-      criticalOverTemperatureThreshold: 280 * 100,
     });
+    // Enable the TemperatureAlarm OverTemperature feature directly on the cabinet endpoint.
+    ovenUpperCabinet.createDefaultTemperatureAlarmClusterServer(280 * 100);
     this.oven.addCabinet('Lower Cabinet', {
       tagList: [{ mfgCode: null, namespaceId: CommonPositionTag.Bottom.namespaceId, tag: CommonPositionTag.Bottom.tag, label: CommonPositionTag.Bottom.label }],
       currentMode: 3,
@@ -2664,7 +2665,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
       step: 1 * 100,
       currentTemperature: 1200,
     });
-    refrigerator.addCabinet('Freezer Bottom', {
+    const freezerBottomCabinet = refrigerator.addCabinet('Freezer Bottom', {
       tagList: [
         { mfgCode: null, namespaceId: CommonPositionTag.Bottom.namespaceId, tag: CommonPositionTag.Bottom.tag, label: 'Freezer Bottom' },
         { mfgCode: null, namespaceId: RefrigeratorTag.Freezer.namespaceId, tag: RefrigeratorTag.Freezer.tag, label: RefrigeratorTag.Freezer.label },
@@ -2674,8 +2675,9 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
       maxTemperature: -10 * 100,
       step: 1 * 100,
       currentTemperature: -1800,
-      criticalUnderTemperatureThreshold: -25 * 100,
     });
+    // Enable the TemperatureAlarm UnderTemperature feature directly on the cabinet endpoint.
+    freezerBottomCabinet.createDefaultTemperatureAlarmClusterServer(undefined, -25 * 100);
     this.refrigerator = await this.addDevice(refrigerator);
 
     // *********************** Create a airConditioner device ***********************

--- a/src/module.ts
+++ b/src/module.ts
@@ -2602,6 +2602,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
       operationalState: OperationalState.OperationalStateEnum.Stopped,
       currentPhase: 2,
       phaseList: ['pre-heating', 'pre-heated', 'cooling down'],
+      criticalOverTemperatureThreshold: 280 * 100,
     });
     this.oven.addCabinet('Lower Cabinet', {
       tagList: [{ mfgCode: null, namespaceId: CommonPositionTag.Bottom.namespaceId, tag: CommonPositionTag.Bottom.tag, label: CommonPositionTag.Bottom.label }],
@@ -2673,6 +2674,7 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
       maxTemperature: -10 * 100,
       step: 1 * 100,
       currentTemperature: -1800,
+      criticalUnderTemperatureThreshold: -25 * 100,
     });
     this.refrigerator = await this.addDevice(refrigerator);
 


### PR DESCRIPTION
Adds a `TemperatureAlarm` example to the Oven/Refrigerator demo cabinets:
- Oven "Upper Cabinet": `criticalOverTemperatureThreshold` (280°C)
- Refrigerator "Freezer Bottom": `criticalUnderTemperatureThreshold` (-25°C)

Requires the matterbridge `TemperatureAlarm` support, which landed directly on `dev` in https://github.com/Luligu/matterbridge/commit/7c8efdbab2e0c1e0369c85a437a0e79751651d69
(`MatterbridgeEndpoint.createDefaultTemperatureAlarmClusterServer(...)`), not yet in a published npm release.

