### PR TITLE
Add ha_entitylabel DIY FixedLabel

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -2426,14 +2426,19 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
       await switch4.addFixedLabel('room', 'Living Room');
       await switch4.addFixedLabel('switch', 'Switch 4');
       await switch4.addFixedLabel('button', 'Button 4');
+      await switch4.addFixedLabel('ha_entitylabel', 'DIY');
+    
       await switch5.addFixedLabel('name', 'Switch 5');
       await switch5.addFixedLabel('room', 'Living Room');
       await switch5.addFixedLabel('switch', 'Switch 5');
       await switch5.addFixedLabel('button', 'Button 5');
+      await switch5.addFixedLabel('ha_entitylabel', 'DIY');
+    
       await switch6.addFixedLabel('name', 'Switch 6');
       await switch6.addFixedLabel('room', 'Living Room');
       await switch6.addFixedLabel('switch', 'Switch 6');
       await switch6.addFixedLabel('button', 'Button 6');
+      await switch6.addFixedLabel('ha_entitylabel', 'DIY');
     }
 
     // *********************** Create a latching switch *****************************/


### PR DESCRIPTION
## Summary

Add a `ha_entitylabel` Fixed Label example to demonstrate Home Assistant interoperability.

### Changes

* Add the `ha_entitylabel` Fixed Label to `switch4`, `switch5`, and `switch6`.
* Use `DIY` as the Fixed Label value.
* Reuse Matterbridge's existing `addFixedLabel()` API.
* No changes to the Matterbridge API or endpoint implementation.

### Result

The example endpoints now expose:

```text
FixedLabel.LabelList
  label: ha_entitylabel
  value: DIY
```

This demonstrates how Matterbridge plugins can expose Home Assistant-compatible entity labels through the standard Matter `FixedLabel` cluster.

### Testing

The change is limited to the existing `momentarySwitch` example and does not alter any existing Fixed Labels or Semantic Tags.


- https://github.com/Luligu/matterbridge-example-dynamic-platform/issues/75