### PR TITLE
fix(Momentary switch): report productId 0x8000 for HA entity-label matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ If you like this project and find it useful, please consider giving it a star on
 - [platform]: Add `RfidLock` device: a door lock with the User, PinCredential, and RfidCredential (RID) features, testing the `numberOfRfidUsersSupported` parameter of `createUserPinDoorLockClusterServer()` (Matter 1.6.0 § 5.2.4). `SetCredential`, `GetCredentialStatus`, and `ClearCredential` already handle `DoorLock.CredentialType.Rfid` generically in `MatterbridgeDoorLockServer`, so no RFID-specific command handlers were needed for this device.
 - [Oven]/[Refrigerator]: Add a `TemperatureAlarm` example to the demo cabinets.
 - [devcontainer]: Upgrade the `Dev Container` to v.2.1.0, using the Node.js and Bun stack.
+- [Momentary switch]: Report `productId` `0x8000` on the composed `Momentary switch` bridged device, so Home Assistant's `(vendorId, productId)` allowlist can match the `ha_entitylabel` FixedLabels on `switch4`/`switch5`/`switch6` (requires matterbridge's `createDefaultBridgedDeviceBasicInformationClusterServer()` optional `productId` parameter).
 
 ### Changed
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -2339,7 +2339,22 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
 
     // *********************** Create a momentary switch ***********************
     this.momentarySwitch = new MatterbridgeEndpoint([bridgedNode, powerSource], { id: 'Momentary switch composed' }, this.config.debug)
-      .createDefaultBridgedDeviceBasicInformationClusterServer('Momentary switch', 'MOS00041', 0xfff1, 'Matterbridge', 'Matterbridge Momentary Switch')
+      // Report productId 0x8000 (Matter test ProductId, paired with the default vendorId 0xfff1) so Home Assistant's (vendorId, productId) allowlist can match the ha_entitylabel FixedLabels below.
+      .createDefaultBridgedDeviceBasicInformationClusterServer(
+        'Momentary switch',
+        'MOS00041',
+        0xfff1,
+        'Matterbridge',
+        'Matterbridge Momentary Switch',
+        1,
+        '1.0.0',
+        1,
+        '1.0.0',
+        'Matter Bridged Endpoint',
+        'https://matterbridge.io',
+        1,
+        0x8000,
+      )
       .createDefaultPowerSourceReplaceableBatteryClusterServer(50, PowerSource.BatChargeLevel.Ok, 2900, 'CR2450', 1);
     fireAndForget(this.momentarySwitch.addFixedLabel('composed', 'Compound device'), this.log, `Failed to add fixed label`);
 


### PR DESCRIPTION
## Summary

Pass `productId` `0x8000` (Matter test ProductId, paired with the default `vendorId` `0xfff1`) to `createDefaultBridgedDeviceBasicInformationClusterServer()` on the composed `Momentary switch` bridged device.

Without it, the `ha_entitylabel` FixedLabels added on `switch4`/`switch5`/`switch6` in #76 were inert: Home Assistant's Matter integration only honors `ha_entitylabel` for an allowlisted set of `(vendorId, productId)` pairs, and a bridged device that never reports a `productId` can never match, regardless of label name (see [home-assistant/core#161974](https://github.com/home-assistant/core/pull/161974)).

## Changes

- `src/module.ts`: pass the new trailing `productId` argument (`0x8000`) to `createDefaultBridgedDeviceBasicInformationClusterServer()` for the `Momentary switch` device, explicitly filling the intermediate default arguments so the positional call stays valid.
- `CHANGELOG.md`: document the change.

## Requires

This depends on the optional `productId` parameter added to `createDefaultBridgedDeviceBasicInformationClusterServer()` in [Luligu/matterbridge#635](https://github.com/Luligu/matterbridge/pull/635), which is still open. Marking this draft until that lands.

## Testing

- `npm run typecheck`, `npm run lint`, `npm run format`, `npm run test` all pass (with matterbridge core rebuilt locally from the linked #635 branch).
- https://github.com/Luligu/matterbridge-example-dynamic-platform/pull/78