### PR TITLE
fix(Momentary switch): use per-switch ha_entitylabel instead of a shared 'DIY' value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ If you like this project and find it useful, please consider giving it a star on
 
 ### Breaking changes
 
-- [matterbridge]: Require matterbridge v.3.10.8 with matter v.1.6.0.
+- [matterbridge]: Require matterbridge v.3.10.10 with matter v.1.6.0.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ If you like this project and find it useful, please consider giving it a star on
 - [platform]: Add `RfidLock` device: a door lock with the User, PinCredential, and RfidCredential (RID) features, testing the `numberOfRfidUsersSupported` parameter of `createUserPinDoorLockClusterServer()` (Matter 1.6.0 § 5.2.4). `SetCredential`, `GetCredentialStatus`, and `ClearCredential` already handle `DoorLock.CredentialType.Rfid` generically in `MatterbridgeDoorLockServer`, so no RFID-specific command handlers were needed for this device.
 - [Oven]/[Refrigerator]: Add a `TemperatureAlarm` example to the demo cabinets.
 - [devcontainer]: Upgrade the `Dev Container` to v.2.1.0, using the Node.js and Bun stack.
+- [Momentary switch]: Report `productId` `0x8000` on the composed `Momentary switch` bridged device, so Home Assistant's `(vendorId, productId)` allowlist can match the `ha_entitylabel` FixedLabels on `switch4`/`switch5`/`switch6` (requires matterbridge's `createDefaultBridgedDeviceBasicInformationClusterServer()` optional `productId` parameter).
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "version": false,
     "publish": false,
     "chip": true,
+    "workflow": "dev",
     "coverage": {
       "lines": 100,
       "functions": 100

--- a/src/module.ts
+++ b/src/module.ts
@@ -2436,7 +2436,9 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
     this.momentarySwitch = await this.addDevice(this.momentarySwitch);
 
     if (this.momentarySwitch) {
-      // This is just a test. No effect so far on any controller
+      // 'name', 'room', 'switch', and 'button' are just tests: no controller currently reads them.
+      // 'ha_entitylabel' is different: Home Assistant's Matter integration reads it to override the entity name,
+      // for bridged devices whose (vendorId, productId) is in its allowlist (see the Momentary switch productId above).
       await switch4.addFixedLabel('name', 'Switch 4');
       await switch4.addFixedLabel('room', 'Living Room');
       await switch4.addFixedLabel('switch', 'Switch 4');

--- a/src/module.ts
+++ b/src/module.ts
@@ -2441,19 +2441,19 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
       await switch4.addFixedLabel('room', 'Living Room');
       await switch4.addFixedLabel('switch', 'Switch 4');
       await switch4.addFixedLabel('button', 'Button 4');
-      await switch4.addFixedLabel('ha_entitylabel', 'DIY');
+      await switch4.addFixedLabel('ha_entitylabel', 'Switch 4');
 
       await switch5.addFixedLabel('name', 'Switch 5');
       await switch5.addFixedLabel('room', 'Living Room');
       await switch5.addFixedLabel('switch', 'Switch 5');
       await switch5.addFixedLabel('button', 'Button 5');
-      await switch5.addFixedLabel('ha_entitylabel', 'DIY');
+      await switch5.addFixedLabel('ha_entitylabel', 'Switch 5');
 
       await switch6.addFixedLabel('name', 'Switch 6');
       await switch6.addFixedLabel('room', 'Living Room');
       await switch6.addFixedLabel('switch', 'Switch 6');
       await switch6.addFixedLabel('button', 'Button 6');
-      await switch6.addFixedLabel('ha_entitylabel', 'DIY');
+      await switch6.addFixedLabel('ha_entitylabel', 'Switch 6');
     }
 
     // *********************** Create a latching switch *****************************/

--- a/src/module.ts
+++ b/src/module.ts
@@ -2339,7 +2339,22 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
 
     // *********************** Create a momentary switch ***********************
     this.momentarySwitch = new MatterbridgeEndpoint([bridgedNode, powerSource], { id: 'Momentary switch composed' }, this.config.debug)
-      .createDefaultBridgedDeviceBasicInformationClusterServer('Momentary switch', 'MOS00041', 0xfff1, 'Matterbridge', 'Matterbridge Momentary Switch')
+      // Report productId 0x8000 (Matter test ProductId, paired with the default vendorId 0xfff1) so Home Assistant's (vendorId, productId) allowlist can match the ha_entitylabel FixedLabels below.
+      .createDefaultBridgedDeviceBasicInformationClusterServer(
+        'Momentary switch',
+        'MOS00041',
+        0xfff1,
+        'Matterbridge',
+        'Matterbridge Momentary Switch',
+        1,
+        '1.0.0',
+        1,
+        '1.0.0',
+        'Matter Bridged Endpoint',
+        'https://matterbridge.io',
+        1,
+        0x8000,
+      )
       .createDefaultPowerSourceReplaceableBatteryClusterServer(50, PowerSource.BatChargeLevel.Ok, 2900, 'CR2450', 1);
     fireAndForget(this.momentarySwitch.addFixedLabel('composed', 'Compound device'), this.log, `Failed to add fixed label`);
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -270,9 +270,9 @@ export class ExampleMatterbridgeDynamicPlatform extends MatterbridgeDynamicPlatf
     super(matterbridge, log, config);
 
     // Verify that Matterbridge is the correct version
-    if (typeof this.verifyMatterbridgeVersion !== 'function' || !this.verifyMatterbridgeVersion('3.10.8')) {
+    if (typeof this.verifyMatterbridgeVersion !== 'function' || !this.verifyMatterbridgeVersion('3.10.10')) {
       throw new Error(
-        `This plugin requires Matterbridge version >= "3.10.8". Please update Matterbridge from ${this.matterbridge.matterbridgeVersion} to the latest version in the frontend.`,
+        `This plugin requires Matterbridge version >= "3.10.10". Please update Matterbridge from ${this.matterbridge.matterbridgeVersion} to the latest version in the frontend.`,
       );
     }
 

--- a/vitest/module.test.ts
+++ b/vitest/module.test.ts
@@ -95,7 +95,7 @@ describe('TestPlatform', () => {
 
   it('should throw error in load when version is not valid', () => {
     expect(() => initializePlugin({ ...matterbridge, matterbridgeVersion: '1.5.0' }, log, config)).toThrow(
-      'This plugin requires Matterbridge version >= "3.10.8". Please update Matterbridge from 1.5.0 to the latest version in the frontend.',
+      'This plugin requires Matterbridge version >= "3.10.10". Please update Matterbridge from 1.5.0 to the latest version in the frontend.',
     );
   });
 


### PR DESCRIPTION
## Summary

Stacked on #77 — this depends on the `productId` fix to be meaningful: `ha_entitylabel` only affects Home Assistant once the bridged device's `(vendorId, productId)` is in its allowlist. Until #77 merges, this diff includes its commit too; please review the top commit only (`use per-switch ha_entitylabel...` + the comment fix).

`switch4`/`switch5`/`switch6` all reported the same `ha_entitylabel` (`'DIY'`), so Home Assistant showed three entities named identically ("Bouton (DIY)"). Each switch now gets its own value (`'Switch 4'`/`'Switch 5'`/`'Switch 6'`), so the entities are distinguishable.

Also fixes the stale comment above these `addFixedLabel()` calls, which claimed none of these labels have any effect on any controller — `ha_entitylabel` does, on Home Assistant, once #77 lands.

## Changes

- `src/module.ts`: distinct `ha_entitylabel` value per switch; corrected comment.

## Testing

- `npm run typecheck`, `npm run lint`, `npm run format`, `npm run test` all pass.
- Verified in a live Home Assistant instance: entities now show as "Bouton (Switch 4)" / "Bouton (Switch 5)" / "Bouton (Switch 6)" instead of three identical "Bouton (DIY)".

<img width="751" height="422" alt="image" src="https://github.com/user-attachments/assets/0d0ad724-e43c-4b76-a149-90a48614b15a" />